### PR TITLE
Fix jobs$ multisubscription issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 coverage
+*.iml
+.idea/

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -19,7 +19,7 @@ export const jobs$ = messageToMain$.pipe(
     []
   ),
   startWith([]),
-  shareReplay()
+  shareReplay(1)
 );
 
 export const newJob$ = jobs$.pipe(

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -19,7 +19,7 @@ export const jobs$ = messageToMain$.pipe(
     []
   ),
   startWith([]),
-  shareReplay(1)
+  shareReplay({ bufferSize: 1, refCount: true })
 );
 
 export const newJob$ = jobs$.pipe(


### PR DESCRIPTION
rxjs `scan` operator keeps a new state for each subscriber.
`shareReplay()` seems to emit full history for each subscriber, which make `newJob$` ticking for nothing with wrong value, starting with the first job ever done.

So the print function `newJobs$` subscription always fetching the first job and immediatly download the wrong bulk as the first job is already finished.

Using `shareReplay(1)` will emit just the last value, which should be the correct job, preventing `newJob$` to tick for nothing.

`shareReplay({ bufferSize: 1, refCount: true })` seems even safer (might not be usefull here though): when the number of subscribers drops to zero, it will also disposes of its source. 