### PR TITLE
Ability to configure scale text

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -41,6 +41,7 @@ export { downloadBlob } from './utils';
 
 /**
  * @typedef {Object} ScaleBarSpec
+ * @property {string} [template] Scale text template. The string `{mapScale}` in the template will be replaced the actual value. Default is `Scale: {mapScale}`.
  * @property {string} position Position on the map. Possible values: "bottom-left" (default), "bottom-right".
  * @property {string} units Units for the graphical scalebar. Possible values: "metric" (default), "degrees", "imperial", "nautical", "us".
  */

--- a/src/printer/scalebar.js
+++ b/src/printer/scalebar.js
@@ -2,6 +2,9 @@ import { getPointResolution, METERS_PER_UNIT } from 'ol/proj';
 import ProjUnits from 'ol/proj/Units';
 import { Units } from 'ol/control/ScaleLine';
 
+const DEFAULT_TITLE = 'Scale: {mapScale}';
+
+
 /**
  * Determines scalebar size and annotation and prints it to map.
  * @param {CanvasRenderingContext2D} ctx
@@ -91,7 +94,7 @@ function getScaleBarParams(frameState, spec) {
       pointResolution /= 1609.3472;
     }
   } else {
-    console.error('Invalid units: Please verifiy your scaleBar object');
+    console.error('Invalid units: Please verify your scaleBar object');
   }
 
   let i = 3 * Math.floor(Math.log(minWidth * pointResolution) / Math.log(10));
@@ -132,7 +135,7 @@ function renderScaleBar(ctx, frameState, scaleBarParams, spec) {
   const scaleText = `${scaleNumber} ${scaleUnit}`;
   const scaleTextWidth = ctx.measureText(scaleText).width;
 
-  const scaleTitle = `Echelle : ${mapScale}`;
+  const scaleTitle = (spec.scaleBar.template ? spec.scaleBar.template : DEFAULT_TITLE).replace('{mapScale}', mapScale);
   const scaleTitleWidth = ctx.measureText(scaleTitle).width;
 
   const line1 = 6;

--- a/test/rendering/cases/05-scalebar/spec.json
+++ b/test/rendering/cases/05-scalebar/spec.json
@@ -9,6 +9,6 @@
   "center": [12, 48],
   "dpi": 50,
   "scale": 40000000,
-  "scaleBar": {"position": "bottom-right", "units": "metric" },
+  "scaleBar": {"position": "bottom-right", "units": "metric", "template": "Echelle : {mapScale}"},
   "projection": "EPSG:3857"
 }


### PR DESCRIPTION
This PR adds a new `template` option to the scale spec to let the user change the displayed text