### PR TITLE
Add multiple jobs example

### DIFF
--- a/demo/elements/custom-button.js
+++ b/demo/elements/custom-button.js
@@ -5,20 +5,11 @@ class CustomButton extends HTMLElement {
     /** @type {boolean} */
     this.working_ = false;
 
-    /** @type {?number} */
-    this.progress_ = null;
-
     /** @type {HTMLButtonElement} */
     this.startBtn = null;
 
     /** @type {HTMLButtonElement} */
     this.waitBtn = null;
-
-    /** @type {HTMLElement} */
-    this.progressBar = null;
-
-    /** @type {HTMLElement} */
-    this.progressBarInner = null;
   }
 
   /**
@@ -29,16 +20,6 @@ class CustomButton extends HTMLElement {
     if (!working) {
       this.progress_ = null;
     }
-    this.refreshDOM();
-  }
-
-  /**
-   * setting a number between 0..1 will make the progress bar appear
-   * setting null will make the progress bar disappear
-   * @param {?number} progress
-   */
-  set progress(progress) {
-    this.progress_ = progress;
     this.refreshDOM();
   }
 
@@ -58,35 +39,15 @@ class CustomButton extends HTMLElement {
     aria-hidden="true"
   ></span>
   Working...
-</button>
-<div class="progress mt-1" style="height: 5px">
-  <div
-    class="progress-bar"
-    style="width: 0"
-    role="progressbar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-  ></div>
-</div>`;
+</button>`;
 
     this.startBtn = this.querySelector('.start-btn');
     this.waitBtn = this.querySelector('.wait-btn');
-    this.progressBar = this.querySelector('.progress');
-    this.progressBarInner = this.progressBar.children.item(0);
 
     this.refreshDOM();
   }
 
   refreshDOM() {
-    if (typeof this.progress_ !== 'number') {
-      this.progressBar.style.visibility = 'hidden';
-      this.progressBarInner.style.width = '0';
-    } else {
-      this.progressBar.style.visibility = 'visible';
-      this.progressBarInner.style.width =
-        Math.round(this.progress_ * 100) + '%';
-    }
-
     this.waitBtn.style.display = this.working_ ? null : 'none';
     this.startBtn.style.display = this.working_ ? 'none' : null;
   }

--- a/demo/elements/custom-progress.js
+++ b/demo/elements/custom-progress.js
@@ -1,0 +1,109 @@
+class CustomProgress extends HTMLElement {
+  static get observedAttributes() {
+    return ['progress', 'status'];
+  }
+
+  constructor() {
+    super();
+
+    /** @type {?number} */
+    this.progress_ = null;
+
+    /** @type {?'pending' | 'ongoing' | 'finished'} */
+    this.status_ = 'pending';
+
+    /** @type {HTMLElement} */
+    this.progressBar = null;
+
+    /** @type {HTMLElement} */
+    this.progressBarInner = null;
+  }
+
+  /**
+   * setting a number between 0..1 will make the progress bar appear
+   * setting null will make the progress bar disappear
+   * @param {?number} progress
+   */
+  set progress(progress) {
+    this.progress_ = progress;
+    this.refreshDOM();
+  }
+
+  /**
+   * setting a status will change the progresse bar color
+   * * pending: secondary
+   * * ongoing: primary
+   * * finished: success
+   *
+   * defaults to pending
+   * @param {?'pending' | 'ongoing' | 'finished'} progress
+   */
+  set status(status) {
+    if (!['pending', 'ongoing', 'finished'].includes(status)) {
+      this.status_ = 'pending';
+    } else {
+      this.status_ = status;
+    }
+    this.refreshDOM();
+  }
+
+  connectedCallback() {
+    this.innerHTML = `
+  <div class="progress mt-1" style="height: 5px; visible">
+    <div
+      class="progress-bar"
+      style="width: 50%"
+      role="progressbar"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    ></div>
+  </div>`;
+
+    this.progressBar = this.querySelector('.progress');
+    this.progressBarInner = this.progressBar.children.item(0);
+
+    this.refreshDOM();
+  }
+
+  attributeChangedCallback(name, _, newValue) {
+    switch (name) {
+      case 'progress':
+        this.progress_ = parseFloat(newValue);
+        break;
+      case 'status':
+        this.status_ = newValue;
+        break;
+    }
+  }
+
+  refreshDOM() {
+    if (typeof this.progress_ !== 'number') {
+      this.progressBar.style.visibility = 'hidden';
+      this.progressBarInner.style.width = '0';
+    } else {
+      this.progressBar.style.visibility = 'visible';
+      this.progressBarInner.style.width =
+        Math.round(this.progress_ * 100) + '%';
+    }
+
+    switch (this.status_) {
+      case 'pending':
+        this.progressBarInner.classList.add('bg-secondary');
+        this.progressBarInner.classList.remove('bg-primary');
+        this.progressBarInner.classList.remove('bg-success');
+        break;
+      case 'ongoing':
+        this.progressBarInner.classList.remove('bg-secondary');
+        this.progressBarInner.classList.add('bg-primary');
+        this.progressBarInner.classList.remove('bg-success');
+        break;
+      case 'finished':
+        this.progressBarInner.classList.remove('bg-secondary');
+        this.progressBarInner.classList.remove('bg-primary');
+        this.progressBarInner.classList.add('bg-success');
+        break;
+    }
+  }
+}
+
+customElements.define('custom-progress', CustomProgress);

--- a/demo/elements/custom-progresses.js
+++ b/demo/elements/custom-progresses.js
@@ -1,0 +1,38 @@
+class CustomProgresses extends HTMLElement {
+  constructor() {
+    super();
+
+    /** @type {?PrintStatus[]} */
+    this.jobsStatus_ = [];
+  }
+
+  /**
+   *
+   * @param {?PrintStatus[]} jobsStatus
+   */
+  set jobsStatus(jobsStatus) {
+    this.jobsStatus_ = jobsStatus;
+    this.refreshDOM();
+  }
+
+  connectedCallback() {
+    this.refreshDOM();
+  }
+
+  refreshDOM() {
+    this.innerHTML = `
+      <div>
+        ${this.jobsStatus_
+          .map(
+            (job) => `
+            <label style="width: 100%">
+                job #${job.id} progress:
+            <custom-progress progress="${job.progress}" status="${job.status}"></custom-progress>
+            </label>`
+          )
+          .join('\n')}
+      </div>`;
+  }
+}
+
+customElements.define('custom-progresses', CustomProgresses);

--- a/demo/examples/02-progress.js
+++ b/demo/examples/02-progress.js
@@ -2,27 +2,33 @@ import { downloadBlob, getJobStatus, queuePrint } from 'inkmap';
 
 const root = document.getElementById('example-02');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
+const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
 const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
 
 btn.addEventListener('click', async () => {
   // display the loading spinner
   btn.working = true;
 
+  // display the job progress
+  bar.progress = 0;
+  bar.status = 'pending';
+
   // create a job, get a promise that resolves with the job id
   const jobId = await queuePrint(spec.value);
 
-  getJobStatus(jobId).subscribe((status) => {
-    // display the job progress
-    btn.progress = status.progress;
+  getJobStatus(jobId).subscribe((printStatus) => {
+    // update the job progress
+    bar.progress = printStatus.progress;
+    bar.status = printStatus.status;
 
     // job is finished
-    if (status.progress === 1) {
+    if (printStatus.progress === 1) {
       // hide the loading spinner
       btn.working = false;
 
       // download the result
       const filename = `inkmap-${new Date().toISOString().substr(0, 10)}.png`;
-      downloadBlob(status.imageBlob, filename);
+      downloadBlob(printStatus.imageBlob, filename);
     }
   });
 });

--- a/demo/examples/04-jobs.js
+++ b/demo/examples/04-jobs.js
@@ -1,0 +1,36 @@
+import { getJobsStatus, queuePrint } from 'inkmap';
+import { tap } from 'rxjs/operators';
+import { downloadBlob, getJobStatus } from '../../src/main';
+
+const root = document.getElementById('example-04');
+const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
+const bars = /** @type {CustomProgresses} */ root.querySelector(
+  'custom-progresses'
+);
+const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+
+// subscribe to the long-running observable
+// beware of managing the unsubscription
+getJobsStatus()
+  .pipe(
+    tap((jobs) => {
+      bars.jobsStatus = jobs;
+    })
+  )
+  .subscribe();
+
+btn.addEventListener('click', async () => {
+  // create a job, get a promise that resolves with the job id
+  const jobId = await queuePrint(spec.value);
+
+  getJobStatus(jobId).subscribe((printStatus) => {
+    // job is finished
+    if (printStatus.progress === 1) {
+      // download the result
+      const filename = `inkmap-${jobId}-${new Date()
+        .toISOString()
+        .substr(0, 10)}.png`;
+      downloadBlob(printStatus.imageBlob, filename);
+    }
+  });
+});

--- a/demo/examples/04-jobs.js
+++ b/demo/examples/04-jobs.js
@@ -11,13 +11,9 @@ const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
 
 // subscribe to the long-running observable
 // beware of managing the unsubscription
-getJobsStatus()
-  .pipe(
-    tap((jobs) => {
-      bars.jobsStatus = jobs;
-    })
-  )
-  .subscribe();
+getJobsStatus().subscribe((jobs) => {
+  bars.jobsStatus = jobs;
+});
 
 btn.addEventListener('click', async () => {
   // create a job, get a promise that resolves with the job id

--- a/demo/index.html
+++ b/demo/index.html
@@ -93,7 +93,7 @@
         <h2>Showing progress</h2>
         <p>
           <strong>inkmap</strong> also enables finer monitoring by making the
-          jobs status observable.
+          job status observable.
         </p>
         <ul class="nav nav-tabs">
           <li class="nav-item">
@@ -114,13 +114,55 @@
           <div class="tab-pane example-02-result show active">
             <div class="row align-items-center">
               <print-spec class="col-8" editable="false"></print-spec>
-              <custom-button class="col-3"> Generate! </custom-button>
+              <div class="col-3">
+                <custom-button> Generate! </custom-button>
+                <custom-progress></custom-progress>
+              </div>
             </div>
           </div>
           <div class="tab-pane example-02-source">
             <pre
               class="rounded small"
             ><code class="js"><%- example02 %></code></pre>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-5" id="example-04">
+        <h2>Monitoring multiple jobs</h2>
+        <p>
+          Multiple jobs can be monitored at once through a long lived
+          observable.
+        </p>
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href=".example-04-result"
+              >Result</a
+            >
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-toggle="tab" href=".example-04-source"
+              >Source</a
+            >
+          </li>
+        </ul>
+        <div class="tab-content mt-2">
+          <div class="tab-pane example-04-result show active">
+            <div class="row align-items-center">
+              <print-spec class="col-8" editable="false"></print-spec>
+              <div class="col-3">
+                <custom-button> Add to the queue </custom-button>
+                <custom-progresses></custom-progresses>
+              </div>
+            </div>
+          </div>
+          <div class="tab-pane example-04-source">
+            <pre
+              class="rounded small"
+            ><code class="js"><%- example04 %></code></pre>
           </div>
         </div>
       </div>

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,4 +1,6 @@
 import './elements/custom-button';
+import './elements/custom-progress';
+import './elements/custom-progresses';
 import './elements/print-spec';
 import './examples/01-simple';
 import './examples/02-progress';

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,7 +4,11 @@ import '../printer';
 import { MESSAGE_JOB_REQUEST } from '../shared/constants';
 import { registerWithExtent } from '../shared/projections';
 import { messageToPrinter } from './exchange';
-import { getJobStatusObservable, newJob$ } from './jobs';
+import {
+  getJobsStatusObservable,
+  getJobStatusObservable,
+  newJob$,
+} from './jobs';
 
 export { downloadBlob } from './utils';
 
@@ -128,8 +132,13 @@ export function queuePrint(printSpec) {
     .toPromise();
 }
 
+/**
+ * Returns a long-running observable which emits an array of print job status.
+ * This observable will never complete.
+ * @return {Observable<PrintStatus[]>} Observable emitting jobs status array.
+ */
 export function getJobsStatus() {
-  console.warn('Not implemented yet');
+  return getJobsStatusObservable();
 }
 
 /**

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -31,6 +31,20 @@ export const newJob$ = jobs$.pipe(
   })
 );
 
+export function getJobsStatusObservable() {
+  return jobs$.pipe(
+    pairwise(),
+    map(([prevJobs, jobs]) =>
+      jobs.filter(
+        (job) =>
+          !prevJobs.find(
+            (prevJob) => prevJob.id === job.id && prevJob.progress == 1
+          )
+      )
+    )
+  );
+}
+
 export function getJobStatusObservable(jobId) {
   return jobs$.pipe(
     map((jobs) => jobs.find((job) => job.id === jobId)),


### PR DESCRIPTION
This PR adds support for multiple jobs monitoring, and illustrate its use through an example.

![image](https://user-images.githubusercontent.com/72435094/103075904-dab6f380-45cc-11eb-8ed3-c66b576eeb48.png)
