### PR TITLE
[GSDESCARTE-7] Handle errors in layer loading process (simplified)

### DIFF
--- a/__mocks__/ol/source/ImageWMS.js
+++ b/__mocks__/ol/source/ImageWMS.js
@@ -1,14 +1,28 @@
 let loadCallback;
+let errorCallback;
 
 export function triggerLoadEnd() {
   loadCallback();
 }
 
-export default class ImageSourceMock {
+export function triggerLoadError(event) {
+  errorCallback(event);
+}
+
+export default class ImageWMSSourceMock {
+  constructor(url) {
+    this.url = url;
+  }
+  getUrl() {
+    return this.url;
+  }
   setImageLoadFunction() {}
   once(type, callback) {
     if (type === 'imageloadend') {
       loadCallback = callback;
+    }
+    if (type === 'imageloaderror') {
+      errorCallback = callback;
     }
   }
 }

--- a/__mocks__/ol/source/TileWMS.js
+++ b/__mocks__/ol/source/TileWMS.js
@@ -1,3 +1,4 @@
 export default class TileWMSSourceMock {
   setTileLoadFunction() {}
+  on() {}
 }

--- a/__mocks__/ol/source/TileWMS.js
+++ b/__mocks__/ol/source/TileWMS.js
@@ -1,4 +1,20 @@
+let errorCallback;
+
+export function triggerLoadError(event) {
+  errorCallback(event);
+}
+
 export default class TileWMSSourceMock {
+  constructor(urls) {
+    this.urls = urls;
+  }
+  getUrls() {
+    return this.urls;
+  }
   setTileLoadFunction() {}
-  on() {}
+  on(type, callback) {
+    if (type === 'tileloaderror') {
+      errorCallback = callback;
+    }
+  }
 }

--- a/__mocks__/ol/source/XYZ.js
+++ b/__mocks__/ol/source/XYZ.js
@@ -1,3 +1,4 @@
 export default class XYZSourceMock {
   setTileLoadFunction() {}
+  on() {}
 }

--- a/__mocks__/ol/source/XYZ.js
+++ b/__mocks__/ol/source/XYZ.js
@@ -1,4 +1,20 @@
+let errorCallback;
+
+export function triggerLoadError(event) {
+  errorCallback(event);
+}
+
 export default class XYZSourceMock {
+  constructor(urls) {
+    this.urls = urls;
+  }
+  getUrls() {
+    return this.urls;
+  }
   setTileLoadFunction() {}
-  on() {}
+  on(type, callback) {
+    if (type === 'tileloaderror') {
+      errorCallback = callback;
+    }
+  }
 }

--- a/demo/elements/print-spec.js
+++ b/demo/elements/print-spec.js
@@ -77,7 +77,11 @@ class PrintSpec extends HTMLElement {
       this.currentSpecName_ = null;
     });
 
-    this.selectSpec(specNames[0]);
+    if (this.getAttribute('select')) {
+      this.selectSpec(this.getAttribute('select'));
+    } else {
+      this.selectSpec(specNames[0]);
+    }
 
     this.refreshDOM();
   }

--- a/demo/examples/07-errors.js
+++ b/demo/examples/07-errors.js
@@ -1,0 +1,40 @@
+import { downloadBlob, getJobStatus, queuePrint } from 'inkmap';
+
+const root = document.getElementById('example-07');
+const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
+const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const errors = root.querySelector('#errors');
+
+btn.addEventListener('click', async () => {
+  // display the loading spinner
+  btn.working = true;
+
+  // create a job, get a promise that resolves with the job id
+  const jobId = await queuePrint(spec.value);
+
+  getJobStatus(jobId).subscribe((status) => {
+    // display the job progress
+    btn.progress = status.progress;
+
+    // job is finished
+    if (status.progress === 1) {
+      // hide the loading spinner
+      btn.working = false;
+
+      // display urls with errors
+      if (status.sourceLoadErrors.length > 0) {
+        let errorMessage = 'The following layers encountered errors:<br>';
+        status.sourceLoadErrors.forEach((element) => {
+          errorMessage = `${errorMessage} - ${element.url}<br>`;
+        });
+        errors.innerHTML = errorMessage;
+      } else {
+        errors.innerHTML = '';
+      }
+
+      // download the result
+      const filename = `inkmap-${new Date().toISOString().substr(0, 10)}.png`;
+      downloadBlob(status.imageBlob, filename);
+    }
+  });
+});

--- a/demo/index.html
+++ b/demo/index.html
@@ -200,6 +200,47 @@
           </div>
         </div>
       </div>
+
+      <div class="mt-5" id="example-07">
+        <h2>Error handling</h2>
+        <p>
+          <strong>inkmap</strong> status observable includes a list of error
+          objects with urls that encountered errors.
+        </p>
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href=".example-07-result"
+              >Result</a
+            >
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-toggle="tab" href=".example-07-source"
+              >Source</a
+            >
+          </li>
+        </ul>
+        <div class="tab-content mt-2">
+          <div class="tab-pane example-07-result show active">
+            <div class="row align-items-center">
+              <print-spec
+                class="col-8"
+                editable="false"
+                select="Error layers"
+              ></print-spec>
+              <custom-button class="col-3"> Generate! </custom-button>
+            </div>
+          </div>
+          <div class="tab-pane example-07-source">
+            <pre
+              class="rounded small"
+            ><code class="js"><%- example07 %></code></pre>
+          </div>
+        </div>
+        <p id="errors" class="text-danger"></p>
+      </div>
     </div>
 
     <script src="app.js"></script>

--- a/demo/index.js
+++ b/demo/index.js
@@ -6,5 +6,6 @@ import './examples/03-cancel';
 import './examples/04-jobs';
 import './examples/05-pdf';
 import './examples/06-projection';
+import './examples/07-errors';
 
 hljs.initHighlightingOnLoad();

--- a/demo/preset-specs.js
+++ b/demo/preset-specs.js
@@ -121,12 +121,47 @@ const CustomProjection = {
   ],
 };
 
+export const ErrorSpec = {
+  layers: [
+    {
+      type: 'WMS',
+      url: 'https://ows.mundialis.de/services/service',
+      layer: 'TOPO-OSM-WMS',
+      tiled: true,
+    },
+    {
+      type: 'WMS',
+      url: 'https://wrong.tiled.wms.url/services/service',
+      layer: 'TOPO-OSM-WMS',
+      tiled: true,
+    },
+    {
+      type: 'WMS',
+      url: 'https://wrong.wms.url/services/service',
+      layer: 'TOPO-OSM-WMS',
+      tiled: false,
+    },
+    {
+      type: 'XYZ',
+      url: 'https://wrong.xyz.url/osm-tiles/{z}/{x}/{y}.png',
+    },
+  ],
+  size: [256, 256],
+  center: [12, 48],
+  dpi: 50,
+  scale: 40000000,
+  scaleBar: { position: 'bottom-right', units: 'metric' },
+  projection: 'EPSG:3857',
+  northArrow: 'top-right',
+};
+
 const PresetSpecs = {
   'OpenStreetMap layer': OsmSpec,
   'Tiled WMS layer': TiledWmsSpec,
   'WMTS layer': WmtsSpec,
   'Downloaded projection': DownloadedProjection,
   'Custom projection': CustomProjection,
+  'Error layers': ErrorSpec,
 };
 
 export default PresetSpecs;

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -20,6 +20,9 @@ const example05 = fs.readFileSync(
 const example06 = fs.readFileSync(
   path.resolve(__dirname, 'examples/06-projection.js')
 );
+const example07 = fs.readFileSync(
+  path.resolve(__dirname, 'examples/07-errors.js')
+);
 
 module.exports = {
   mode: 'development',
@@ -47,6 +50,7 @@ module.exports = {
         example04,
         example05,
         example06,
+        example07,
       },
       inject: false,
     }),

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -93,12 +93,12 @@ export { downloadBlob } from './utils';
  * @property {number} progress Job progress, from 0 to 1.
  * @property {'pending' | 'ongoing' | 'finished'} status Job status.
  * @property {Blob} [imageBlob] Finished image blob.
- * @property {Array<SourceLoadError>} [sourceLoadErrors] Array of sources that encountered at least one 'tileloaderror' or 'imageloaderror'.
+ * @property {SourceLoadError[]} [sourceLoadErrors] Array of `SourceLoadError` objects.
  */
 
 /**
  * @typedef {Object} SourceLoadError
- * @property {ol.source} source ol source that encountered at least one 'tileloaderror' or 'imageloaderror'.
+ * @property {string} url url of the ol.source that encountered at least one 'tileloaderror' or 'imageloaderror'.
  * /
 
 /**

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -93,7 +93,13 @@ export { downloadBlob } from './utils';
  * @property {number} progress Job progress, from 0 to 1.
  * @property {'pending' | 'ongoing' | 'finished'} status Job status.
  * @property {Blob} [imageBlob] Finished image blob.
+ * @property {Array<SourceLoadError>} [sourceLoadErrors] Array of sources that encountered at least one 'tileloaderror' or 'imageloaderror'.
  */
+
+/**
+ * @typedef {Object} SourceLoadError
+ * @property {ol.source} source ol source that encountered at least one 'tileloaderror' or 'imageloaderror'.
+ * /
 
 /**
  * Starts generating a map image from a print spec.

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -57,11 +57,11 @@ export async function createJob(spec) {
         if (allReady) {
           for (let i = 0; i < layerStates.length; i++) {
             const canvasImage = layerStates[i][1];
-            const errorSource = layerStates[i][2];
+            const errorUrl = layerStates[i][2];
             context.drawImage(canvasImage, 0, 0);
-            if (errorSource) {
+            if (errorUrl) {
               sourceLoadErrors.push({
-                source: errorSource,
+                url: errorUrl,
               });
             }
           }

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -39,6 +39,7 @@ export async function createJob(spec) {
     spec,
     status: 'pending',
     progress: 0,
+    sourceLoadErrors: [],
   };
 
   const context = createCanvasContext2D(sizeInPixel[0], sizeInPixel[1]);
@@ -51,10 +52,18 @@ export async function createJob(spec) {
     .pipe(
       switchMap((layerStates) => {
         const allReady = layerStates.every(([progress]) => progress === 1);
+        let sourceLoadErrors = [];
 
         if (allReady) {
           for (let i = 0; i < layerStates.length; i++) {
-            context.drawImage(layerStates[i][1], 0, 0);
+            const canvasImage = layerStates[i][1];
+            const errorSource = layerStates[i][2];
+            context.drawImage(canvasImage, 0, 0);
+            if (errorSource) {
+              sourceLoadErrors.push({
+                source: errorSource,
+              });
+            }
           }
           if (spec.northArrow) {
             printNorthArrow(context, spec.northArrow);
@@ -62,22 +71,25 @@ export async function createJob(spec) {
           if (spec.scaleBar) {
             printScaleBar(context, frameState, spec);
           }
-          return canvasToBlob(context.canvas).pipe(map((blob) => [1, blob]));
+          return canvasToBlob(context.canvas).pipe(
+            map((blob) => [1, blob, sourceLoadErrors])
+          );
         } else {
           const rawProgress =
             layerStates.reduce((prev, [progress]) => progress + prev, 0) /
             layerStates.length;
           const progress = parseFloat(rawProgress.toFixed(4)); // only keep 4 digits precision
 
-          return of([progress, null]);
+          return of([progress, null, sourceLoadErrors]);
         }
       }),
-      map(([progress, imageBlob]) => {
+      map(([progress, imageBlob, sourceLoadErrors]) => {
         return {
           ...job,
           progress,
           imageBlob,
           status: progress === 1 ? 'finished' : 'ongoing',
+          sourceLoadErrors,
         };
       }),
       takeWhile((jobStatus) => jobStatus.progress < 1, true)

--- a/src/printer/layers.js
+++ b/src/printer/layers.js
@@ -52,6 +52,7 @@ function createTiledLayer(source, rootFrameState, opacity) {
   let frameState;
   let layer;
   let renderer;
+  let tileLoadErrorSource;
 
   layer = new TileLayer({
     transition: 0,
@@ -72,6 +73,10 @@ function createTiledLayer(source, rootFrameState, opacity) {
     }
 
     image.src = src;
+  });
+
+  layer.getSource().on('tileloaderror', function (e) {
+    tileLoadErrorSource = e.target;
   });
 
   frameState = {
@@ -128,9 +133,9 @@ function createTiledLayer(source, rootFrameState, opacity) {
           { ...frameState, time: Date.now() },
           context.canvas
         );
-        return [1, context.canvas];
+        return [1, context.canvas, tileLoadErrorSource];
       } else {
-        return [progress, null];
+        return [progress, null, tileLoadErrorSource];
       }
     }),
     throttleTime(500, undefined, { leading: true, trailing: true })
@@ -226,11 +231,16 @@ function createLayerWMS(layerSpec, rootFrameState) {
     };
   };
 
-  const progress$ = new BehaviorSubject([0, null]);
+  const progress$ = new BehaviorSubject([0, null, undefined]);
+  layer.getSource().once('imageloaderror', function (e) {
+    const imageLoadErrorSource = e.target;
+    progress$.next([1, context.canvas, imageLoadErrorSource]);
+    progress$.complete();
+  });
   layer.getSource().once('imageloadend', () => {
     renderer.prepareFrame({ ...frameState, time: Date.now() });
     renderer.renderFrame({ ...frameState, time: Date.now() }, context.canvas);
-    progress$.next([1, context.canvas]);
+    progress$.next([1, context.canvas, undefined]);
     progress$.complete();
   });
   renderer.prepareFrame({ ...frameState, time: Date.now() });

--- a/src/printer/layers.js
+++ b/src/printer/layers.js
@@ -52,7 +52,7 @@ function createTiledLayer(source, rootFrameState, opacity) {
   let frameState;
   let layer;
   let renderer;
-  let tileLoadErrorSource;
+  let tileLoadErrorUrl;
 
   layer = new TileLayer({
     transition: 0,
@@ -76,7 +76,7 @@ function createTiledLayer(source, rootFrameState, opacity) {
   });
 
   layer.getSource().on('tileloaderror', function (e) {
-    tileLoadErrorSource = e.target;
+    tileLoadErrorUrl = e.target.getUrls()[0];
   });
 
   frameState = {
@@ -133,9 +133,9 @@ function createTiledLayer(source, rootFrameState, opacity) {
           { ...frameState, time: Date.now() },
           context.canvas
         );
-        return [1, context.canvas, tileLoadErrorSource];
+        return [1, context.canvas, tileLoadErrorUrl];
       } else {
-        return [progress, null, tileLoadErrorSource];
+        return [progress, null, tileLoadErrorUrl];
       }
     }),
     throttleTime(500, undefined, { leading: true, trailing: true })
@@ -233,8 +233,8 @@ function createLayerWMS(layerSpec, rootFrameState) {
 
   const progress$ = new BehaviorSubject([0, null, undefined]);
   layer.getSource().once('imageloaderror', function (e) {
-    const imageLoadErrorSource = e.target;
-    progress$.next([1, context.canvas, imageLoadErrorSource]);
+    const imageLoadErrorUrl = e.target.getUrl();
+    progress$.next([1, context.canvas, imageLoadErrorUrl]);
     progress$.complete();
   });
   layer.getSource().once('imageloadend', () => {

--- a/src/printer/scalebar.js
+++ b/src/printer/scalebar.js
@@ -4,7 +4,6 @@ import { Units } from 'ol/control/ScaleLine';
 
 const DEFAULT_TITLE = 'Scale: {mapScale}';
 
-
 /**
  * Determines scalebar size and annotation and prints it to map.
  * @param {CanvasRenderingContext2D} ctx
@@ -135,7 +134,10 @@ function renderScaleBar(ctx, frameState, scaleBarParams, spec) {
   const scaleText = `${scaleNumber} ${scaleUnit}`;
   const scaleTextWidth = ctx.measureText(scaleText).width;
 
-  const scaleTitle = (spec.scaleBar.template ? spec.scaleBar.template : DEFAULT_TITLE).replace('{mapScale}', mapScale);
+  const scaleTitle = (spec.scaleBar.template
+    ? spec.scaleBar.template
+    : DEFAULT_TITLE
+  ).replace('{mapScale}', mapScale);
   const scaleTitleWidth = ctx.measureText(scaleTitle).width;
 
   const line1 = 6;

--- a/test/unit/printer/job.test.js
+++ b/test/unit/printer/job.test.js
@@ -34,7 +34,7 @@ const spec = {
   scale: 40000000,
   projection: 'EPSG:3857',
 };
-
+const errorurl = 'https://my.url/z/y/x.png';
 let layerSubjects;
 
 LayersMock.createLayer = jest.fn(() => {
@@ -91,8 +91,8 @@ describe('job creation', () => {
       },
     });
   });
-  it('prints all layers to a final canvas when finished', () => {
-    layerSubjects[0].next([1, { style: {} }]);
+  it('prints all layers to a final canvas and passes errorurls to status when finished', () => {
+    layerSubjects[0].next([1, { style: {} }, errorurl]);
     layerSubjects[1].next([1, { style: {} }]);
     layerSubjects[2].next([1, { style: {} }]);
     expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
@@ -102,7 +102,9 @@ describe('job creation', () => {
         progress: 1,
         spec,
         status: 'finished',
-        sourceLoadErrors: []
+        sourceLoadErrors: [{
+          url: errorurl
+        }]
       },
     });
   });

--- a/test/unit/printer/job.test.js
+++ b/test/unit/printer/job.test.js
@@ -38,7 +38,7 @@ const spec = {
 let layerSubjects;
 
 LayersMock.createLayer = jest.fn(() => {
-  const layer$ = new BehaviorSubject([0, null]);
+  const layer$ = new BehaviorSubject([0, null, undefined]);
   layerSubjects.push(layer$);
   return layer$;
 });
@@ -72,13 +72,14 @@ describe('job creation', () => {
         progress: 0,
         spec,
         status: 'ongoing',
+        sourceLoadErrors: []
       },
     });
   });
   it('broadcast advancement status', () => {
-    layerSubjects[0].next([0.1, null]);
-    layerSubjects[1].next([0.9, null]);
-    layerSubjects[2].next([0.2, null]);
+    layerSubjects[0].next([0.1, null, undefined]);
+    layerSubjects[1].next([0.9, null, undefined]);
+    layerSubjects[2].next([0.2, null, undefined]);
     expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
       status: {
         id: expect.any(Number),
@@ -86,6 +87,7 @@ describe('job creation', () => {
         progress: 0.4,
         spec,
         status: 'ongoing',
+        sourceLoadErrors: []
       },
     });
   });
@@ -100,6 +102,7 @@ describe('job creation', () => {
         progress: 1,
         spec,
         status: 'finished',
+        sourceLoadErrors: []
       },
     });
   });

--- a/test/unit/printer/layers.test.js
+++ b/test/unit/printer/layers.test.js
@@ -83,25 +83,25 @@ describe('layer creation', () => {
     });
 
     it('initially emit a status with progress 0', () => {
-      expect(received).toEqual([0, null]);
+      expect(received).toEqual([0, null, undefined]);
     });
 
     it('status updates are sent regularly', () => {
       tileQueue._setQueuedCount(12, 12);
-      expect(received).toEqual([0.4, null]);
+      expect(received).toEqual([0.4, null, undefined]);
 
       tileQueue._setQueuedCount(2, 2);
-      expect(received).toEqual([0.9, null]);
+      expect(received).toEqual([0.9, null, undefined]);
     });
 
     it('when no queued elements left but tiles are remaining, do not complete', () => {
       tileQueue._setQueuedCount(0, 2);
-      expect(received).toEqual([0.999, null]);
+      expect(received).toEqual([0.999, null, undefined]);
     });
 
     it('when observable completes, canvas is received', () => {
       tileQueue._setQueuedCount(0, 0);
-      expect(received).toEqual([1, expect.objectContaining({})]);
+      expect(received).toEqual([1, expect.objectContaining({}), undefined]);
       expect(completed).toBeTruthy();
     });
   });
@@ -129,14 +129,14 @@ describe('layer creation', () => {
     });
 
     it('initially emit a status with progress 0', () => {
-      expect(received).toEqual([0, null]);
+      expect(received).toEqual([0, null, undefined]);
     });
 
     it('when observable completes, canvas is received', () => {
       triggerLoadEnd();
       jest.runOnlyPendingTimers();
 
-      expect(received).toEqual([1, expect.objectContaining({})]);
+      expect(received).toEqual([1, expect.objectContaining({}), undefined]);
       expect(completed).toBeTruthy();
     });
   });
@@ -167,25 +167,25 @@ describe('layer creation', () => {
     });
 
     it('initially emit a status with progress 0', () => {
-      expect(received).toEqual([0, null]);
+      expect(received).toEqual([0, null, undefined]);
     });
 
     it('status updates are sent regularly', () => {
       tileQueue._setQueuedCount(12, 12);
-      expect(received).toEqual([0.4, null]);
+      expect(received).toEqual([0.4, null, undefined]);
 
       tileQueue._setQueuedCount(2, 2);
-      expect(received).toEqual([0.9, null]);
+      expect(received).toEqual([0.9, null, undefined]);
     });
 
     it('when no queued elements left but tiles are remaining, do not complete', () => {
       tileQueue._setQueuedCount(0, 2);
-      expect(received).toEqual([0.999, null]);
+      expect(received).toEqual([0.999, null, undefined]);
     });
 
     it('when observable completes, canvas is received', () => {
       tileQueue._setQueuedCount(0, 0);
-      expect(received).toEqual([1, expect.objectContaining({})]);
+      expect(received).toEqual([1, expect.objectContaining({}), undefined]);
       expect(completed).toBeTruthy();
     });
   });

--- a/test/unit/printer/layers.test.js
+++ b/test/unit/printer/layers.test.js
@@ -1,5 +1,7 @@
 import { createLayer } from '../../../src/printer/layers';
-import { triggerLoadEnd } from '../../../__mocks__/ol/source/ImageWMS';
+import ImageWMSSourceMock, { triggerLoadEnd, triggerLoadError } from '../../../__mocks__/ol/source/ImageWMS';
+import TileWMSSourceMock, { triggerLoadError as triggerTileWMSError }  from '../../../__mocks__/ol/source/TileWMS';
+import XYZSourceMock, { triggerLoadError as triggerXYZError } from '../../../__mocks__/ol/source/XYZ';
 
 /** @type {FrameState} */
 const frameState = {
@@ -58,6 +60,12 @@ class TileQueueMock {
   }
 }
 
+export class SourceEventMock {
+  constructor(target) {
+    this.target = target;
+  }
+}
+
 jest.useFakeTimers();
 describe('layer creation', () => {
   describe('XYZ layer creation', () => {
@@ -70,6 +78,8 @@ describe('layer creation', () => {
     let received;
     let tileQueue;
     let completed;
+    const xyzSourceMock = new XYZSourceMock(['testurl']);
+    const tileErrorEventMock = new SourceEventMock(xyzSourceMock);
 
     beforeEach(() => {
       tileQueue = /** @type {TileQueue} */ new TileQueueMock(20);
@@ -104,6 +114,19 @@ describe('layer creation', () => {
       expect(received).toEqual([1, expect.objectContaining({}), undefined]);
       expect(completed).toBeTruthy();
     });
+
+    it('when error occurs during tile loading, error url is received', () => {
+      triggerXYZError(tileErrorEventMock);
+      tileQueue._setQueuedCount(2, 2);
+      expect(received).toEqual([0.9, null, 'testurl']);
+    });
+
+    it('when observable completes with error, canvas and error url are received', () => {
+      triggerXYZError(tileErrorEventMock);
+      tileQueue._setQueuedCount(0, 0);
+      expect(received).toEqual([1, expect.objectContaining({}), 'testurl']);
+      expect(completed).toBeTruthy();
+    });
   });
 
   describe('WMS layer creation', () => {
@@ -117,6 +140,8 @@ describe('layer creation', () => {
     let layer$;
     let received;
     let completed;
+    const imageWMSSourceMock = new ImageWMSSourceMock('testurl');
+    const errorEventMock = new SourceEventMock(imageWMSSourceMock);
 
     beforeEach(() => {
       completed = false;
@@ -139,6 +164,14 @@ describe('layer creation', () => {
       expect(received).toEqual([1, expect.objectContaining({}), undefined]);
       expect(completed).toBeTruthy();
     });
+
+    it('when observable completes with error, canvas and error url are received', () => {
+      triggerLoadError(errorEventMock);
+      jest.runOnlyPendingTimers();
+
+      expect(received).toEqual([1, expect.objectContaining({}), 'testurl']);
+      expect(completed).toBeTruthy();
+    });
   });
 
   describe('tiled WMS layer creation', () => {
@@ -154,6 +187,8 @@ describe('layer creation', () => {
     let received;
     let tileQueue;
     let completed;
+    const tileWMSSourceMock = new TileWMSSourceMock(['testurl']);
+    const tileErrorEventMock = new SourceEventMock(tileWMSSourceMock);
 
     beforeEach(() => {
       tileQueue = /** @type {TileQueue} */ new TileQueueMock(20);
@@ -186,6 +221,19 @@ describe('layer creation', () => {
     it('when observable completes, canvas is received', () => {
       tileQueue._setQueuedCount(0, 0);
       expect(received).toEqual([1, expect.objectContaining({}), undefined]);
+      expect(completed).toBeTruthy();
+    });
+
+    it('when error occurs during tile loading, error url is received', () => {
+      triggerTileWMSError(tileErrorEventMock);
+      tileQueue._setQueuedCount(2, 2);
+      expect(received).toEqual([0.9, null, 'testurl']);
+    });
+
+    it('when observable completes with error, canvas and error url are received', () => {
+      triggerTileWMSError(tileErrorEventMock);
+      tileQueue._setQueuedCount(0, 0);
+      expect(received).toEqual([1, expect.objectContaining({}), 'testurl']);
       expect(completed).toBeTruthy();
     });
   });


### PR DESCRIPTION
 This PR ascends tile and image loading errors into job status if a source encounters at least one `tileloaderror` or `imageloaderror`. In this case the job status indicates the error prone source. It covers `XYZ`, `TileWMS` and `ImageWMS`.

The PR also ensures that maps are printed if loading errors occur which was not the case for non-tiled WMS before.

Can easily be tested by copying (incomplete) demo data or indicating wrong urls like:

```
{
  "layers": [
    {
      "type": "XYZ",
      "url": "/data/osm-tiles/{z}/{x}/{y}.png"
    },
    {
      "type": "WMS",
      "url": "https://ows.mundialis.de/services/service",
      "layer": "TOPO-OSM-WMS",
      "tiled": true
    },
    {
      "type": "WMS",
      "url": "https://ows.mundialise.de/services/service",
      "layer": "TOPO-OSM-WMS",
      "tiled": true
    },
    {
      "type": "WMS",
      "url": "https://ows.mundialise.de/services/service",
      "layer": "TOPO-OSM-WMS",
      "tiled": false
    },
    {
      "type": "WMS",
      "url": "https://ows.mundialis.de/services/service",
      "layer": "TOPO-OSM-WMS",
      "tiled": false
    }
  ],
  "size": [
    256,
    256
  ],
  "center": [
    12,
    48
  ],
  "dpi": 50,
  "scale": 40000000,
  "scaleBar": {
    "position": "bottom-right",
    "units": "metric"
  },
  "projection": "EPSG:3857",
  "northArrow": "top-right"
}
```