### PR TITLE
Builds library

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
-demo/dist/*
+demo/dist
+dist
+./*.js
+__mocks__

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+demo/dist/*

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+CeCILL-C FREE SOFTWARE LICENSE AGREEMENT
 
 
     Notice
@@ -16,7 +16,7 @@ the two main principles guiding its drafting:
       intellectual property law, and the protection that it offers to
       both authors and holders of the economic rights over software.
 
-The authors of the CeCILL-B (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
+The authors of the CeCILL-C (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
 license are:
 
 Commissariat � l'Energie Atomique - CEA, a public scientific, technical
@@ -35,14 +35,12 @@ principal place of business at Domaine de Voluceau, Rocquencourt, BP
 
     Preamble
 
-This Agreement is an open source software license intended to give users
-significant freedom to modify and redistribute the software licensed
-hereunder.
+The purpose of this Free Software license agreement is to grant users
+the right to modify and re-use the software governed by this license.
 
-The exercising of this freedom is conditional upon a strong obligation
-of giving credits for everybody that distributes a software
-incorporating a software ruled by the current license so as all
-contributions to be properly identified and acknowledged.
+The exercising of this right is conditional upon the obligation to make
+available to the community the modifications made to the source code of
+the software so as to contribute to its evolution.
 
 In consideration of access to the source code and the rights to copy,
 modify and redistribute granted by the license, users are provided only
@@ -83,7 +81,7 @@ Object Code form and, where applicable, its documentation, "as is" when
 it is first distributed under the terms and conditions of the Agreement.
 
 Modified Software: means the Software modified by at least one
-Contribution.
+Integrated Contribution.
 
 Source Code: means all the Software's instructions and program lines to
 which access is required so as to modify the Software.
@@ -96,25 +94,23 @@ Software.
 
 Licensee: means the Software user(s) having accepted the Agreement.
 
-Contributor: means a Licensee having made at least one Contribution.
+Contributor: means a Licensee having made at least one Integrated
+Contribution.
 
 Licensor: means the Holder, or any other individual or legal entity, who
 distributes the Software under the Agreement.
 
-Contribution: means any or all modifications, corrections, translations,
-adaptations and/or new functions integrated into the Software by any or
-all Contributors, as well as any or all Internal Modules.
+Integrated Contribution: means any or all modifications, corrections,
+translations, adaptations and/or new functions integrated into the
+Source Code by any or all Contributors.
 
-Module: means a set of sources files including their documentation that
-enables supplementary functions or services in addition to those offered
-by the Software.
+Related Module: means a set of sources files including their
+documentation that, without modification to the Source Code, enables
+supplementary functions or services in addition to those offered by the
+Software.
 
-External Module: means any or all Modules, not derived from the
-Software, so that this Module and the Software run in separate address
-spaces, with one calling the other when they are run.
-
-Internal Module: means any or all Module, connected to the Software so
-that they both execute in the same address space.
+Derivative Software: means any combination of the Software, modified or
+not, and of a Related Module.
 
 Parties: mean both the Licensee and the Licensor.
 
@@ -199,15 +195,16 @@ that this comprises:
       to carry out hereunder.
 
 
-      5.2 ENTITLEMENT TO MAKE CONTRIBUTIONS
+      5.2 RIGHT OF MODIFICATION
 
-The right to make Contributions includes the right to translate, adapt,
+The right of modification includes the right to translate, adapt,
 arrange, or make any or all modifications to the Software, and the right
-to reproduce the resulting software.
+to reproduce the resulting software. It includes, in particular, the
+right to create a Derivative Software.
 
-The Licensee is authorized to make any or all Contributions to the
+The Licensee is authorized to make any or all modification to the
 Software provided that it includes an explicit notice that it is the
-author of said Contribution and indicates the date of the creation thereof.
+author of said modification and indicates the date of the creation thereof.
 
 
       5.3 RIGHT OF DISTRIBUTION
@@ -244,54 +241,54 @@ transferring the data.
 
         5.3.2 DISTRIBUTION OF MODIFIED SOFTWARE
 
-If the Licensee makes any Contribution to the Software, the resulting
-Modified Software may be distributed under a license agreement other
-than this Agreement subject to compliance with the provisions of Article
-5.3.4.
+When the Licensee makes an Integrated Contribution to the Software, the
+terms and conditions for the distribution of the resulting Modified
+Software become subject to all the provisions of this Agreement.
+
+The Licensee is authorized to distribute the Modified Software, in
+source code or object code form, provided that said distribution
+complies with all the provisions of the Agreement and is accompanied by:
+
+   1. a copy of the Agreement,
+
+   2. a notice relating to the limitation of both the Licensor's
+      warranty and liability as set forth in Articles 8 and 9,
+
+and that, in the event that only the object code of the Modified
+Software is redistributed, the Licensee allows effective access to the
+full source code of the Modified Software at a minimum during the entire
+period of its distribution of the Modified Software, it being understood
+that the additional cost of acquiring the source code shall not exceed
+the cost of transferring the data.
 
 
-        5.3.3 DISTRIBUTION OF EXTERNAL MODULES
+        5.3.3 DISTRIBUTION OF DERIVATIVE SOFTWARE
 
-When the Licensee has developed an External Module, the terms and
-conditions of this Agreement do not apply to said External Module, that
-may be distributed under a separate license agreement.
+When the Licensee creates Derivative Software, this Derivative Software
+may be distributed under a license agreement other than this Agreement,
+subject to compliance with the requirement to include a notice
+concerning the rights over the Software as defined in Article 6.4.
+In the event the creation of the Derivative Software required modification
+of the Source Code, the Licensee undertakes that:
 
-
-        5.3.4 CREDITS
-
-Any Licensee who may distribute a Modified Software hereby expressly
-agrees to:
-
-   1. indicate in the related documentation that it is based on the
-      Software licensed hereunder, and reproduce the intellectual
-      property notice for the Software,
-
-   2. ensure that written indications of the Software intended use,
-      intellectual property notice and license hereunder are included in
-      easily accessible format from the Modified Software interface,
-
-   3. mention, on a freely accessible website describing the Modified
-      Software, at least throughout the distribution term thereof, that
-      it is based on the Software licensed hereunder, and reproduce the
-      Software intellectual property notice,
-
-   4. where it is distributed to a third party that may distribute a
-      Modified Software without having to make its source code
-      available, make its best efforts to ensure that said third party
-      agrees to comply with the obligations set forth in this Article .
-
-If the Software, whether or not modified, is distributed with an
-External Module designed for use in connection with the Software, the
-Licensee shall submit said External Module to the foregoing obligations.
+   1. the resulting Modified Software will be governed by this Agreement,
+   2. the Integrated Contributions in the resulting Modified Software
+      will be clearly identified and documented,
+   3. the Licensee will allow effective access to the source code of the
+      Modified Software, at a minimum during the entire period of
+      distribution of the Derivative Software, such that such
+      modifications may be carried over in a subsequent version of the
+      Software; it being understood that the additional cost of
+      purchasing the source code of the Modified Software shall not
+      exceed the cost of transferring the data.
 
 
-        5.3.5 COMPATIBILITY WITH THE CeCILL AND CeCILL-C LICENSES
+        5.3.4 COMPATIBILITY WITH THE CeCILL LICENSE
 
-Where a Modified Software contains a Contribution subject to the CeCILL
-license, the provisions set forth in Article 5.3.4 shall be optional.
-
-A Modified Software may be distributed under the CeCILL-C license. In
-such a case the provisions set forth in Article 5.3.4 shall be optional.
+When a Modified Software contains an Integrated Contribution subject to
+the CeCILL license agreement, or when a Derivative Software contains a
+Related Module subject to the CeCILL license agreement, the provisions
+set forth in the third item of Article 6.4 are optional.
 
 
     Article 6 - INTELLECTUAL PROPERTY
@@ -309,22 +306,22 @@ The Holder undertakes that the Initial Software will remain ruled at
 least by this Agreement, for the duration set forth in Article 4.2.
 
 
-      6.2 OVER THE CONTRIBUTIONS
+      6.2 OVER THE INTEGRATED CONTRIBUTIONS
 
-The Licensee who develops a Contribution is the owner of the
+The Licensee who develops an Integrated Contribution is the owner of the
 intellectual property rights over this Contribution as defined by
 applicable law.
 
 
-      6.3 OVER THE EXTERNAL MODULES
+      6.3 OVER THE RELATED MODULES
 
-The Licensee who develops an External Module is the owner of the
-intellectual property rights over this External Module as defined by
+The Licensee who develops a Related Module is the owner of the
+intellectual property rights over this Related Module as defined by
 applicable law and is free to choose the type of agreement that shall
-govern its distribution.
+govern its distribution under the conditions defined in Article 5.3.3.
 
 
-      6.4 JOINT PROVISIONS
+      6.4 NOTICE OF RIGHTS
 
 The Licensee expressly undertakes:
 
@@ -332,7 +329,12 @@ The Licensee expressly undertakes:
       notices attached to the Software;
 
    2. to reproduce said notices, in an identical manner, in the copies
-      of the Software modified or not.
+      of the Software modified or not;
+
+   3. to ensure that use of the Software, its intellectual property
+      notices and the fact that it is governed by the Agreement is
+      indicated in a text that is easily accessible, specifically from
+      the interface of any Derivative Software.
 
 The Licensee undertakes not to directly or indirectly infringe the
 intellectual property rights of the Holder and/or Contributors on the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div style="text-align: center"><strong>inkmap</strong>, a library for generating high resolution maps in the browser</div>
 
+
+##### [Live demo here!](https://camptocamp.github.io/inkmap/master/)
+
 ## Introduction
 
 **inkmap** is based on [OpenLayers](https://www.openlayers.org) and will generate maps in PNG format based on a given JSON specification.
@@ -7,27 +10,20 @@
 **inkmap** can handle long-running jobs (e.g. A0 format in 300 dpi) and provides an API for following a job progress.
 It uses a service worker in the background provided the user browser supports [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas), and falls back (almost) seamlessly to the main thread if not.
 
-
-## Demo
-[Demo](https://camptocamp.github.io/inkmap/master/)
-
-## Disclaimer
-**inkmap is still in development mode.**
-
-**inkmap is not published on npm yet.**
+Please note that **inkmap** has been entirely funded and supported by the [French Ministry of Ecology](https://www.ecologie.gouv.fr/) as part of their Descartes web mapping toolkit.
 
 ## Usage
 
-**(Not available yet)**
+### Basic
 
 To include the library in your project:
 ```bash
-$ npm install --save inkmap
+$ npm install --save @camptocamp/inkmap
 ```
 
 Then import the different methods from the `inkmap` package:
 ```js
-import { print, getJobsStatus } from 'inkmap';
+import { print, getJobsStatus } from '@camptocamp/inkmap';
 
 print({
   layers: [ ... ],
@@ -38,9 +34,36 @@ print({
 getJobsStatus().subscribe(jobs => ...);
 ```
 
+### Enabling the service worker
+
+**inkmap** can _and will_ use a dedicated service worker for running print jobs if given the chance. This offers the following
+advantages:
+* Jobs run in a separate thread, meaning the user navigation will not be impacted at all by any CPU-intensive task
+* The service worker isn't tied to a window or tab, so jobs will continue running when the tab is closed (and even when the browser is closed, depending on the platform)
+* Push notifications might be sent to the user when a print job complete (not implemented yet)
+
+**To enable this, the `inkmap-worker.js` file located in the `dist` folder must be published on the same path as the application
+using inkmap**.
+
+The worker file can be published either using a symbolic link or by actually copying the file, for example in the application build pipeline.
+
+If using Webpack to build the application, a solution is to use the [CopyWebpackPlugin](https://webpack.js.org/plugins/copy-webpack-plugin/):
+
+```js
+module.exports = {
+  ...
+  plugins: [
+     new CopyWebpackPlugin([
+       { from: 'node_modules/@camptocamp/inkmap/dist/inkmap-worker.js', to: '/dist' },
+     ]),
+  ],
+  ...
+}
+```
+
 ## API
 
-All API functions are named exports from the `inkmap` package.
+Important note: all API functions are named exports from the `inkmap` package.
 
 #### `print(jsonSpec: PrintSpec): Observable<PrintStatus>`
 
@@ -97,7 +120,7 @@ A `Layer` object describes a layer in the printed map.
 
 #### `WMS layer` type
 
-Additionnal options for `WMS` layer type.
+Additional options for `WMS` layer type.
 
 | field | type | description |
 |---|---|---|
@@ -106,7 +129,7 @@ Additionnal options for `WMS` layer type.
 
 #### `WMTS layer` type
 
-Additionnal options for `WMTS` layer to define the layer source. See https://openlayers.org/en/latest/apidoc/module-ol_source_WMTS-WMTS.html
+Additional options for `WMTS` layer to define the layer source. See https://openlayers.org/en/latest/apidoc/module-ol_source_WMTS-WMTS.html
 for the full list of options. The following table introduces the common options to use.
 
 | field | type | description |
@@ -121,7 +144,7 @@ for the full list of options. The following table introduces the common options 
 
 #### `WFS layer` type
 
-Additionnal options for `WFS` layer type.
+Additional options for `WFS` layer type.
 
 | field | type | description |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 **inkmap** can handle long-running jobs (e.g. A0 format in 300 dpi) and provides an API for following a job progress.
 It uses a service worker in the background provided the user browser supports [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas), and falls back (almost) seamlessly to the main thread if not.
 
-Please note that **inkmap** has been entirely funded and supported by the [French Ministry of Ecology](https://www.ecologie.gouv.fr/) as part of their Descartes web mapping toolkit.
+Please note that **inkmap** has been entirely funded and supported by the [French Ministry of Ecology](https://www.ecologie.gouv.fr/) as part of their Descartes web mapping toolkit, hosted here: https://adullact.net/projects/descartes/
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@camptocamp/inkmap",
-  "version": "1.0.0-RC1",
+  "version": "1.0.0-RC3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "inkmap",
+  "name": "@camptocamp/inkmap",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1502,6 +1502,45 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz",
+      "integrity": "sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+          "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
@@ -1703,10 +1742,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-      "dev": true,
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -5044,9 +5082,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "optional": true
     },
@@ -5254,21 +5292,13 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-          "dev": true
-        }
       }
     },
     "browserify-sign": {
@@ -5523,20 +5553,20 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       },
       "dependencies": {
         "braces": {
@@ -5558,6 +5588,13 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+          "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+          "dev": true,
+          "optional": true
         },
         "is-number": {
           "version": "7.0.0",
@@ -6650,9 +6687,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8494,9 +8531,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-ip": {
@@ -12543,9 +12580,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -14124,9 +14161,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -14648,21 +14685,21 @@
       }
     },
     "watchpack": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "watchpack-chokidar2": "^2.0.1"
       }
     },
     "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -14795,9 +14832,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
-      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -14808,7 +14845,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.3.0",
+        "enhanced-resolve": "^4.5.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@camptocamp/inkmap",
-  "version": "0.0.1",
+  "version": "1.0.0-RC1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,22 +1607,6 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.1.tgz",
@@ -1843,11 +1827,6 @@
           }
         }
       }
-    },
-    "@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3943,55 +3922,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/chroma-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
-      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
-    },
-    "@types/codemirror": {
-      "version": "0.0.96",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.96.tgz",
-      "integrity": "sha512-GTswEV26Bl1byRxpD3sKd1rT2AISr0rK9ImlJgEzfvqhcVWeu4xQKFQI6UgSC95NT5swNG4st/oRMeGVZgPj9w==",
-      "requires": {
-        "@types/tern": "*"
-      }
-    },
-    "@types/color": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.1.tgz",
-      "integrity": "sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==",
-      "requires": {
-        "@types/color-convert": "*"
-      }
-    },
-    "@types/color-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
-      "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
-      "requires": {
-        "@types/color-name": "*"
-      }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
-    },
-    "@types/file-saver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.1.tgz",
-      "integrity": "sha512-g1QUuhYVVAamfCifK7oB7G3aIl4BbOyzDOqVyUfEr4tfBKrXfeH+M+Tg7HKCXSrbzxYdhyCP7z9WbKo0R2hBCw=="
-    },
-    "@types/geojson": {
-      "version": "7946.0.7",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -4020,12 +3950,14 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -4039,84 +3971,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "@types/jest": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
-      "requires": {
-        "jest-diff": "^24.3.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "diff-sequences": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
-        },
-        "jest-diff": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-          "requires": {
-            "chalk": "^2.0.1",
-            "diff-sequences": "^24.9.0",
-            "jest-get-type": "^24.9.0",
-            "pretty-format": "^24.9.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-          "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.168",
@@ -4140,7 +3999,8 @@
     "@types/node": {
       "version": "14.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
-      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
+      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4154,58 +4014,12 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
-    "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
-    },
     "@types/raf": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
       "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
       "dev": true,
       "optional": true
-    },
-    "@types/react": {
-      "version": "16.14.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.3.tgz",
-      "integrity": "sha512-zPrXn03hmPYqh9DznqSFQsoRtrQ4aHgnZDO+hMGvsE/PORvDTdJCHQ6XvJV31ic+0LzF73huPFXUb++W6Kri0Q==",
-      "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
-        }
-      }
-    },
-    "@types/react-color": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.4.tgz",
-      "integrity": "sha512-EswbYJDF1kkrx93/YU+BbBtb46CCtDMvTiGmcOa/c5PETnwTiSWoseJ1oSWeRl/4rUXkhME9bVURvvPg0W5YQw==",
-      "requires": {
-        "@types/react": "*",
-        "@types/reactcss": "*"
-      }
-    },
-    "@types/react-dom": {
-      "version": "16.9.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
-      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
-      "requires": {
-        "@types/react": "^16"
-      }
-    },
-    "@types/reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-d2gQQ0IL6hXLnoRfVYZukQNWHuVsE75DzFTLPUuyyEhJS8G2VvlE+qfQQ91SJjaMqlURRCNIsX7Jcsw6cEuJlA==",
-      "requires": {
-        "@types/react": "*"
-      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -4224,14 +4038,6 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
-    },
-    "@types/tern": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
-      "requires": {
-        "@types/estree": "*"
-      }
     },
     "@types/uglify-js": {
       "version": "3.11.1",
@@ -4306,14 +4112,6 @@
         }
       }
     },
-    "@types/xml2js": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
-      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/yargs": {
       "version": "15.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
@@ -4326,7 +4124,8 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "@types/yauzl": {
       "version": "2.9.1",
@@ -4337,11 +4136,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@ungap/url-search-params": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@ungap/url-search-params/-/url-search-params-0.2.2.tgz",
-      "integrity": "sha512-qQsguKXZVKdCixOHX9jqnX/K/1HekPDpGKyEcXHT+zR6EjGA7S4boSuelL4uuPv6YfhN0n8c4UxW+v/Z3gM2iw=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -4644,12 +4438,14 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -5122,14 +4918,6 @@
         }
       }
     },
-    "blob": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.1.0.tgz",
-      "integrity": "sha512-k+GwK+4Rj+MPNT4qu+y6+kHp+mPmmNd+28zdrIo69QM9UvypK5Vhcw7jnRiY4KaOMAiOdn0NtPQGTb+Ox1Dtng==",
-      "requires": {
-        "esm": "^3.2.25"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5540,6 +5328,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5621,14 +5410,6 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
-    "chroma-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.0.tgz",
-      "integrity": "sha512-uiRdh4ZZy+UTPSrAdp8hqEdVb1EllLtTHOt5TMaOjJUvi+O54/83Fc5K2ld1P+TJX+dw5B+8/sCgzI6eaur/lg==",
-      "requires": {
-        "cross-env": "^6.0.3"
-      }
-    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -5682,11 +5463,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -5762,11 +5538,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "codemirror": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.2.tgz",
-      "integrity": "sha512-/D5PcsKyzthtSy2NNKCyJi3b+htRkoKv3idswR/tR6UAvMNKA7SrmyZy6fOONJxSRs1JlUWEDAbxqfdArbK8iA=="
-    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -5783,19 +5554,11 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -5803,16 +5566,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -6067,52 +5822,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
-      "requires": {
-        "cross-spawn": "^7.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6200,11 +5909,6 @@
           "dev": true
         }
       }
-    },
-    "csstype": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -6794,7 +6498,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",
@@ -7075,11 +6780,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "espree": {
       "version": "7.3.0",
@@ -7521,11 +7221,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
-    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -7568,11 +7263,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-saver": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -7595,6 +7285,11 @@
           }
         }
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -7824,87 +7519,6 @@
         "rbush": "*"
       }
     },
-    "geostyler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-4.6.1.tgz",
-      "integrity": "sha512-WbfghLyyjmJZyEK5auYpZy4GWOrBBWOkyoKqpnfvnxuKJlA+z7CcbLnKT4B/Hh0UL9Fros+nMSFk9whtnxsxdw==",
-      "requires": {
-        "@babel/polyfill": "^7.10.4",
-        "@types/chroma-js": "^2.0.0",
-        "@types/codemirror": "^0.0.96",
-        "@types/color": "^3.0.0",
-        "@types/file-saver": "^2.0.1",
-        "@types/geojson": "^7946.0.7",
-        "@types/lodash": "^4.14.159",
-        "@types/react": "^16.9.46",
-        "@types/react-color": "^3.0.4",
-        "@types/react-dom": "^16.9.8",
-        "@ungap/url-search-params": "^0.2.2",
-        "blob": "^0.1.0",
-        "chroma-js": "^2.0.3",
-        "codemirror": "^5.56.0",
-        "color": "^3.1.2",
-        "csstype": "^2.6.13",
-        "file-saver": "^2.0.2",
-        "geostyler-cql-parser": "^1.0.0",
-        "geostyler-data": "^1.0.0",
-        "geostyler-geojson-parser": "^1.0.1",
-        "geostyler-openlayers-parser": "^2.1.0",
-        "geostyler-sld-parser": "^2.0.1",
-        "geostyler-style": "^2.1.0",
-        "geostyler-wfs-parser": "^1.0.1",
-        "lodash": "^4.17.15",
-        "moment": "^2.27.0",
-        "react-codemirror2": "^7.2.1",
-        "react-color": "^2.18.1",
-        "react-rnd": "^10.2.1"
-      }
-    },
-    "geostyler-cql-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/geostyler-cql-parser/-/geostyler-cql-parser-1.0.0.tgz",
-      "integrity": "sha512-iqnIrAJ7n6qfZFnvoX/XTEQM/I1nUthmNmQX4Jxg9UAbz0ZJuP03IQN0sC7AbWIii8Jn16ijSZuqZb2jI+Ca5Q==",
-      "requires": {
-        "geostyler-style": "^2.0.3",
-        "lodash": "^4.17.15"
-      }
-    },
-    "geostyler-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/geostyler-data/-/geostyler-data-1.0.0.tgz",
-      "integrity": "sha512-ctmk6OsunL427Uaa1HME/blTyBbl0Ihu+vPV1Irqz3ip80qvNLwDEr46xI5HwMeyrsWH8o76kfA0sF6oecW1BA==",
-      "requires": {
-        "@types/geojson": "7946.0.7",
-        "@types/json-schema": "7.0.3"
-      },
-      "dependencies": {
-        "@types/json-schema": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-          "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
-        }
-      }
-    },
-    "geostyler-geojson-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-geojson-parser/-/geostyler-geojson-parser-1.0.1.tgz",
-      "integrity": "sha512-b7eJ2sCrYCC7fIDItxfbDH9r55dE58OXTQjPb/kIlXgH+7A2o2xp7pQlRXu5xCqM5lucQAAM9A7IfLLhbflznw==",
-      "requires": {
-        "@babel/polyfill": "^7.4.4",
-        "@types/geojson": "^7946.0.7",
-        "@types/jest": "^24.0.18",
-        "@types/json-schema": "^7.0.3",
-        "@types/node": "^12.7.3",
-        "geostyler-data": "^1.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.19.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
-        }
-      }
-    },
     "geostyler-openlayers-parser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.1.0.tgz",
@@ -7915,35 +7529,10 @@
         "lodash": "^4.17.15"
       }
     },
-    "geostyler-sld-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-2.1.0.tgz",
-      "integrity": "sha512-R6WQ/49b5nFOaYS9PLvgHniptiGsPg3M3NzBX5GBra5aQR1yAQ76d7M+xi0CBJV1l8FNMnpZftR70u0ukBYbqg==",
-      "requires": {
-        "geostyler-style": "^2.1.0",
-        "lodash": "^4.17.19",
-        "xml2js": "^0.4.23",
-        "xmldom": "^0.2.1"
-      }
-    },
     "geostyler-style": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.1.0.tgz",
       "integrity": "sha512-m8bCtckOBZrVZwZ4Vh02kFY2ttLZlSZYMsYPqcNp+/ruIBwADJZvxnsjuY+t63PMsw0s9R05yPVyjVMwtaD/sA=="
-    },
-    "geostyler-wfs-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-wfs-parser/-/geostyler-wfs-parser-1.0.1.tgz",
-      "integrity": "sha512-pR+sYfG6B3iS735LnbRgnYq4SyLIMr5KctuBxtbiluInJUtGjsWfppKw9tMXbCIcHbO9bYoeKcbqMq2L/T//8g==",
-      "requires": {
-        "@types/geojson": "^7946.0.7",
-        "@types/json-schema": "^7.0.3",
-        "@types/lodash": "^4.14.138",
-        "@types/xml2js": "^0.4.4",
-        "geostyler-data": "^1.0.0",
-        "lodash": "^4.17.15",
-        "xml2js": "^0.4.19"
-      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -8134,7 +7723,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -8843,7 +8433,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -10673,7 +10264,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -10932,11 +10524,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
-    "lodash-es": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10947,14 +10534,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
       "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lower-case": {
       "version": "2.0.2",
@@ -11020,11 +10599,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
-    },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11221,11 +10795,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -12138,23 +11707,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "protocol-buffers-schema": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
@@ -12336,11 +11888,12 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.13.8",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
+      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
@@ -12430,72 +11983,11 @@
         "quickselect": "^2.0.0"
       }
     },
-    "re-resizable": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
-      "integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
-      "requires": {
-        "fast-memoize": "^2.5.1"
-      }
-    },
-    "react-codemirror2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
-    },
-    "react-color": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
-    "react-draggable": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.3.tgz",
-      "integrity": "sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
-    },
-    "react-rnd": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.2.4.tgz",
-      "integrity": "sha512-wseACIsxa1wuZz9XatO3/JAZR748Sddehh0NtJz1Yj3X5BQm5pwRShiadfnWrUajJATurHbN0NVTUn+jEkHkPw==",
-      "requires": {
-        "re-resizable": "6.9.0",
-        "react-draggable": "4.4.3",
-        "tslib": "2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-        }
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "requires": {
-        "lodash": "^4.0.1"
-      }
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -13039,11 +12531,6 @@
         }
       }
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13305,21 +12792,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
-      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -13945,6 +13417,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -14168,11 +13641,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tinyqueue": {
       "version": "2.0.3",
@@ -15483,30 +14951,11 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.2.1.tgz",
-      "integrity": "sha512-kXXiYvmblIgEemGeB75y97FyaZavx6SQhGppLw5TKWAD2Wd0KAly0g23eVLh17YcpxZpnFym1Qk/eaRjy1APPg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "inkmap",
+  "name": "@camptocamp/inkmap",
   "version": "0.0.1",
   "description": "A library for generating printable, high quality maps in the browser.",
-  "main": "index.js",
+  "main": "dist/inkmap.js",
   "scripts": {
     "lint": "eslint src",
     "format": "prettier --write src demo test",
@@ -10,7 +10,8 @@
     "test:unit": "jest",
     "test:rendering": "node test/rendering/run.js",
     "demo": "webpack-dev-server --config demo/webpack.config.js",
-    "build:demo": "webpack --config demo/webpack.config.js --mode production"
+    "build:demo": "webpack --config demo/webpack.config.js --mode production",
+    "build:lib": "webpack --config ./webpack.config.js --mode production"
   },
   "repository": {
     "type": "git",
@@ -30,11 +31,13 @@
   "dependencies": {
     "geostyler": "^4.6.1",
     "ol": "^6.5.0",
+    "@babel/runtime": "^7.12.5",
     "proj4": "^2.6.3",
     "rxjs": "^6.6.3"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
+    "@babel/plugin-transform-runtime": "^7.12.10",
     "@babel/preset-env": "^7.12.1",
     "babel-jest": "^26.6.1",
     "babel-loader": "^8.0.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@camptocamp/inkmap",
-  "version": "1.0.0-RC1",
+  "version": "1.0.0-RC3",
   "description": "A library for generating printable, high quality maps in the browser.",
-  "main": "dist/inkmap.js",
+  "main": "src/main/index.js",
   "files": [
     "dist/",
     "src/"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,22 @@
 {
   "name": "@camptocamp/inkmap",
-  "version": "0.0.1",
+  "version": "1.0.0-RC1",
   "description": "A library for generating printable, high quality maps in the browser.",
   "main": "dist/inkmap.js",
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "scripts": {
     "lint": "eslint src",
     "format": "prettier --write src demo test",
-    "format:check": "prettier src demo test",
+    "format:check": "prettier --check src demo test",
     "test:unit": "jest",
     "test:rendering": "node test/rendering/run.js",
     "demo": "webpack-dev-server --config demo/webpack.config.js",
     "build:demo": "webpack --config demo/webpack.config.js --mode production",
-    "build:lib": "webpack --config ./webpack.config.js --mode production"
+    "build:lib": "rm -rf dist && webpack --config ./webpack.config.js --mode production",
+    "prepublishOnly": "npm run lint && npm run format:check && npm run test:unit && npm run test:rendering && npm run build:lib"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@camptocamp/inkmap",
-  "version": "1.0.0-RC3",
+  "version": "1.0.0-RC4",
   "description": "A library for generating printable, high quality maps in the browser.",
   "main": "src/main/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/camptocamp/inkmap#readme",
   "dependencies": {
-    "geostyler": "^4.6.1",
-    "ol": "^6.5.0",
     "@babel/runtime": "^7.12.5",
+    "geostyler-openlayers-parser": "^2.1.0",
+    "ol": "^6.5.0",
     "proj4": "^2.6.3",
     "rxjs": "^6.6.3"
   },

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -20,7 +20,7 @@ export function downloadBlob(imageBlob, filename) {
  * True means a worker is used for print jobs
  * @type {Promise<boolean>}
  */
-export const printerReady = new Promise((resolve, reject) => {
+export const printerReady = new Promise((resolve) => {
   if (hasOffscreenCanvasSupport()) {
     navigator.serviceWorker.register('inkmap-worker.js').then(
       () => {
@@ -32,9 +32,11 @@ export const printerReady = new Promise((resolve, reject) => {
           resolve(true);
         }, 100);
       },
-      (error) => {
-        console.log('Service worker registration failed:', error);
-        reject();
+      () => {
+        console.log(
+          '[inkmap] Service worker was not found. See https://github.com/camptocamp/inkmap for using multi-threading'
+        );
+        resolve(false);
       }
     );
   } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,61 @@
+const path = require('path');
+
+module.exports = [{
+  devtool: 'source-map',
+  //generate inkmap.js lib with umd target to run in browser window
+  entry: {
+    inkmap: path.resolve(__dirname, './src/main/index.js'),
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+    library: '@camptocamp/inkmap',
+    libraryTarget: 'umd',
+  },
+  module: getBabelLoader()
+},
+{
+  devtool: 'source-map',
+  //generate inkmap-worker.js without umd target to run in background
+  entry: {
+    ['inkmap-worker']: path.resolve(
+      __dirname,
+      'src',
+      'worker',
+      'index.js'
+    ),
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+  },
+  module: getBabelLoader()
+}];
+
+function getBabelLoader() {
+  return {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              ['@babel/preset-env']
+            ],
+            // transpile promises to ES5 ("regeneratorRuntime is not defined")
+            plugins: [
+              [
+                "@babel/plugin-transform-runtime",
+                {
+                  "regenerator": true,
+                }
+              ]
+            ]
+          },
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
This PR builds the library (including its service worker). The service worker needs to be served where the lib is used.

PR can be tested with a simple webpack-starter (https://github.com/tkohr/print-app) that installs inkmap locally via `npm install <path-to-your-inkmap-dir>` and serves service worker via `contentBase` in dev.

PR also works for descartes/d-inkmap, but it needs transpiling of Promises via `@babel/plugin-transform-runtime`.

TODOS:
- [x] document using service worker
- [x] improve typing and sourcemaps
- [x] license ?
- [x] publish to npm (ignoring unnecessary files)