### PR TITLE
Indicates GetFeature BBOX without epsg code

### DIFF
--- a/src/printer/utils.js
+++ b/src/printer/utils.js
@@ -87,7 +87,7 @@ export function generateGetFeatureUrl(
   urlObj.searchParams.set('request', 'GetFeature');
   urlObj.searchParams.set(typeNameLabel, layerName);
   urlObj.searchParams.set('srsName', projCode);
-  urlObj.searchParams.set('bbox', `${extent.join(',')},${projCode}`);
+  urlObj.searchParams.set('bbox', `${extent.join(',')}`);
   if (format === 'geojson') {
     urlObj.searchParams.set('outputFormat', 'application/json');
   }

--- a/test/unit/printer/layers.test.js
+++ b/test/unit/printer/layers.test.js
@@ -283,7 +283,7 @@ describe('layer creation', () => {
         frameState.extent
       );
       expect(url).toEqual(
-        'https://my.url/wfs?SERVICE=WFS&version=1.1.0&request=GetFeature&typename=my%3Alayername&srsName=EPSG%3A3857&bbox=-696165.0132013096%2C5090855.383524774%2C3367832.7922398755%2C7122854.286245367%2CEPSG%3A3857&outputFormat=application%2Fjson'
+        'https://my.url/wfs?SERVICE=WFS&version=1.1.0&request=GetFeature&typename=my%3Alayername&srsName=EPSG%3A3857&bbox=-696165.0132013096%2C5090855.383524774%2C3367832.7922398755%2C7122854.286245367&outputFormat=application%2Fjson'
       );
     });
   });


### PR DESCRIPTION
PR removes EPSG code from BBOX param in GetFeature request, as it seem superfluous as long as the BBOX is in the same SRS as the request and some WFS (as the one from Descartes tests) do not support this feature.