### PR TITLE
Allow specifying WMS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Additional options for `WMS` layer type.
 | field | type | description |
 |---|---|---|
 | `layer` | `string` | Layer name. |
+| `version` | `string` | Version of WMS protocol used: `1.1.1` or `1.3.0` (default). |
 | `tiled` | `boolean` | Indicates whether the WMS layer should be requested as tiles. Defaults to `false`. |
 
 #### `WMTS layer` type

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -27,6 +27,7 @@ export { downloadBlob } from './utils';
  * @property {'WMS'} type
  * @property {string} url
  * @property {string} layer Layer name.
+ * @property {string} version Version of WMS protocol used: `1.1.1` or `1.3.0` (default).
  * @property {number} opacity Opacity, from 0 (hidden) to 1 (visible).
  * @property {boolean} [tiled=false] Whether the WMS layer should be requested as tiles.
  */

--- a/src/printer/layers.js
+++ b/src/printer/layers.js
@@ -167,6 +167,23 @@ function createLayerXYZ(jobId, layerSpec, rootFrameState) {
 
 /**
  * @param {WmsLayer} layerSpec
+ * @return {Object.<string, string|boolean>}
+ */
+export function getWMSParams(layerSpec) {
+  return layerSpec.tiled
+    ? {
+        LAYERS: layerSpec.layer,
+        VERSION: layerSpec.version || '1.3.0',
+        TILED: true,
+      }
+    : {
+        LAYERS: layerSpec.layer,
+        VERSION: layerSpec.version || '1.3.0',
+      };
+}
+
+/**
+ * @param {WmsLayer} layerSpec
  * @param {FrameState} rootFrameState
  * @return {Observable<LayerPrintStatus>}
  */
@@ -177,7 +194,7 @@ function createLayerWMS(jobId, layerSpec, rootFrameState) {
       new TileWMS({
         crossOrigin: 'anonymous',
         url: layerSpec.url,
-        params: { LAYERS: layerSpec.layer, TILED: true },
+        params: getWMSParams(layerSpec),
         transition: 0,
       }),
       rootFrameState,
@@ -199,7 +216,7 @@ function createLayerWMS(jobId, layerSpec, rootFrameState) {
     source: new ImageWMS({
       crossOrigin: 'anonymous',
       url: layerSpec.url,
-      params: { LAYERS: layerSpec.layer },
+      params: getWMSParams(layerSpec),
       ratio: 1,
     }),
   });


### PR DESCRIPTION
This allows targetting WMS services that do not support version 1.3.0, and as such expect a `SRS` parameter in the GetMap requests instead of `CRS`.