### PR TITLE
Use one tile queue per layer instead of one per job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,8 @@ jobs:
         uses: scherermichael-oss/action-has-permission@master
         with:
           required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Only if user has write permission
       - name: Deploy

--- a/__mocks__/ol/TileQueue.js
+++ b/__mocks__/ol/TileQueue.js
@@ -1,0 +1,28 @@
+const TILE_COUNT_MOCK = 20
+
+export function setQueuedCount(count, remainingTilesCount) {
+  instance.queuedCount = count;
+  instance.remaining = remainingTilesCount;
+  jest.runOnlyPendingTimers();
+}
+
+let instance = null
+
+export default class TileQueueMock {
+  constructor() {
+    this.remaining = TILE_COUNT_MOCK;
+    this.queuedCount = TILE_COUNT_MOCK;
+    instance = this;
+  }
+  reprioritize() {}
+  loadMoreTiles() {}
+  getTilesLoading() {
+    return this.remaining;
+  }
+  get queuedElements_() {
+    // this will generate an object with one key per tile
+    return new Array(this.queuedCount)
+      .fill(0)
+      .reduce((prev, curr, index) => ({ ...prev, [index]: true }), {});
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -90,7 +90,7 @@ export { downloadBlob } from './utils';
  * @property {number} scale Scale denominator.
  * @property {string} projection EPSG projection code.
  * @property {boolean | string} northArrow North arrow position.
- * @property {ProjectionDefinition} projectionDefinition Projection definition to be newly registered.
+ * @property {ProjectionDefinition} projectionDefinitions Projection definitions to be newly registered.
  * @property {string} attributions Position where the attributions should be printed
  */
 

--- a/src/printer/exchange.js
+++ b/src/printer/exchange.js
@@ -15,13 +15,12 @@ export function messageToMain(type, message) {
         type: 'window',
       })
       .then((clients) => {
-        if (clients && clients.length) {
-          // clients array is ordered by last focused
-          clients[0].postMessage({
+        clients.forEach((client) => {
+          client.postMessage({
             ...message,
             type,
           });
-        }
+        });
       });
   } else {
     window.dispatchEvent(

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -28,7 +28,7 @@ let counter = 0;
  * @param {import('../main/index').PrintSpec} spec
  */
 export async function createJob(spec) {
-  registerProjections(spec.projectionDefinition);
+  registerProjections(spec.projectionDefinitions);
   const sizeInPixel = calculateSizeInPixel(spec);
   const frameState = await getFrameState(spec, sizeInPixel);
 

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -1,22 +1,14 @@
 import { createCanvasContext2D } from 'ol/dom';
-import { getForViewAndSize } from 'ol/extent';
-import { fromLonLat, get as getProjection } from 'ol/proj';
-import TileQueue, {
-  getTilePriority as tilePriorityFunction,
-} from 'ol/TileQueue';
 import { combineLatest, of } from 'rxjs';
 import { map, switchMap, takeWhile } from 'rxjs/operators';
 
-import { CM_PER_INCH, MESSAGE_JOB_STATUS } from '../shared/constants';
-import {
-  registerWithExtent,
-  search as searchProjection,
-} from '../shared/projections';
+import { MESSAGE_JOB_STATUS } from '../shared/constants';
+import { registerWithExtent } from '../shared/projections';
 import { messageToMain } from './exchange';
 import { cancel$, createLayer } from './layers';
 import { printNorthArrow } from './north-arrow';
 import { printScaleBar } from './scalebar';
-import { canvasToBlob } from './utils';
+import { calculateSizeInPixel, canvasToBlob, getJobFrameState } from './utils';
 import { printAttributions } from './attributions';
 
 let counter = 0;
@@ -30,7 +22,7 @@ let counter = 0;
 export async function createJob(spec) {
   registerProjections(spec.projectionDefinitions);
   const sizeInPixel = calculateSizeInPixel(spec);
-  const frameState = await getFrameState(spec, sizeInPixel);
+  const frameState = await getJobFrameState(spec, sizeInPixel);
 
   /**
    * @type {import('../main/index').PrintStatus}
@@ -114,117 +106,12 @@ export async function createJob(spec) {
     .subscribe((status) => messageToMain(MESSAGE_JOB_STATUS, { status }));
 }
 
-/**
- * Returns an OpenLayers frame state for a given job spec
- * @param {import('../main/index').PrintSpec} spec
- * @param {Array} sizeInPixel
- * @return {import('ol/PluggableMap').FrameState}
- */
-async function getFrameState(spec, sizeInPixel) {
-  let projection = getProjection(spec.projection);
-
-  if (!projection && spec.projection.startsWith('EPSG:')) {
-    const splitted = spec.projection.split(':');
-    const { name, proj4def, bbox } = await searchProjection(splitted[1]);
-    registerWithExtent(name, proj4def, bbox);
-    projection = getProjection(spec.projection);
-  }
-
-  const inchPerMeter = 39.3701;
-  const resolution =
-    spec.scale / spec.dpi / inchPerMeter / projection.getMetersPerUnit();
-
-  const viewState = {
-    center: fromLonLat(spec.center, projection),
-    resolution,
-    projection,
-    rotation: 0,
-  };
-
-  const frameState = {
-    animate: false,
-    coordinateToPixelTransform: [1, 0, 0, 1, 0, 0],
-    declutterItems: [],
-    extent: getForViewAndSize(
-      viewState.center,
-      viewState.resolution,
-      viewState.rotation,
-      sizeInPixel
-    ),
-    index: 0,
-    layerIndex: 0,
-    layerStatesArray: [],
-    pixelRatio: 1,
-    pixelToCoordinateTransform: [1, 0, 0, 1, 0, 0],
-    postRenderFunctions: [],
-    size: sizeInPixel,
-    time: Date.now(),
-    usedTiles: {},
-    viewState: viewState,
-    viewHints: [0, 0],
-    wantedTiles: {},
-  };
-
-  frameState.tileQueue = new TileQueue(
-    (tile, tileSourceKey, tileCenter, tileResolution) =>
-      tilePriorityFunction(
-        frameState,
-        tile,
-        tileSourceKey,
-        tileCenter,
-        tileResolution
-      ),
-    () => {}
-  );
-
-  return frameState;
-}
-
 function registerProjections(definitions) {
   if (definitions) {
     for (const projection of definitions) {
       registerWithExtent(projection.name, projection.proj4, projection.bbox);
     }
   }
-}
-
-/**
- * Returns the map canvas size in pixels based on size units and dpi given in spec
- * @param {import('../main/index').PrintSpec} spec
- * @return {[number, number]}
- */
-function calculateSizeInPixel(spec) {
-  const { size, dpi } = spec;
-  if (!size[2] || size[2] === 'px') {
-    return [size[0], size[1]];
-  }
-  let pixelX;
-  let pixelY;
-  const unit = size[2];
-
-  switch (unit) {
-    case 'in':
-      pixelX = dpi * size[0];
-      pixelY = dpi * size[1];
-      break;
-    case 'cm':
-      pixelX = (dpi * size[0]) / CM_PER_INCH;
-      pixelY = (dpi * size[1]) / CM_PER_INCH;
-      break;
-    case 'mm':
-      pixelX = (dpi * size[0]) / (CM_PER_INCH * 10);
-      pixelY = (dpi * size[1]) / (CM_PER_INCH * 10);
-      break;
-    case 'm':
-      pixelX = (dpi * size[0] * 100) / CM_PER_INCH;
-      pixelY = (dpi * size[1] * 100) / CM_PER_INCH;
-      break;
-    default:
-      pixelX = size[0];
-      pixelY = size[1];
-  }
-
-  return [Math.round(pixelX), Math.round(pixelY)];
 }
 
 export function cancelJob(jobId) {

--- a/src/printer/utils.js
+++ b/src/printer/utils.js
@@ -1,6 +1,16 @@
 import { isWorker } from '../worker/utils';
 import { from, Observable } from 'rxjs';
 import sourceState from 'ol/source/State';
+import { fromLonLat, get as getProjection } from 'ol/proj';
+import {
+  registerWithExtent,
+  search as searchProjection,
+} from '../shared/projections';
+import { getForViewAndSize } from 'ol/extent';
+import TileQueue, {
+  getTilePriority as tilePriorityFunction,
+} from 'ol/TileQueue';
+import { CM_PER_INCH } from '../shared/constants';
 
 /**
  * Transforms a canvas to a Blob through an observable
@@ -21,13 +31,108 @@ export function canvasToBlob(canvas) {
 }
 
 /**
+ * Returns an OpenLayers frame state for a given job spec
+ * This frame state will be used as a basis for all layers
+ * @param {import('../main/index').PrintSpec} spec
+ * @param {Array} sizeInPixel
+ * @return {import('ol/PluggableMap').FrameState}
+ */
+export async function getJobFrameState(spec, sizeInPixel) {
+  let projection = getProjection(spec.projection);
+
+  if (!projection && spec.projection.startsWith('EPSG:')) {
+    const splitted = spec.projection.split(':');
+    const { name, proj4def, bbox } = await searchProjection(splitted[1]);
+    registerWithExtent(name, proj4def, bbox);
+    projection = getProjection(spec.projection);
+  }
+
+  const inchPerMeter = 39.3701;
+  const resolution =
+    spec.scale / spec.dpi / inchPerMeter / projection.getMetersPerUnit();
+
+  const viewState = {
+    center: fromLonLat(spec.center, projection),
+    resolution,
+    projection,
+    rotation: 0,
+  };
+
+  return {
+    animate: false,
+    coordinateToPixelTransform: [1, 0, 0, 1, 0, 0],
+    declutterItems: [],
+    extent: getForViewAndSize(
+      viewState.center,
+      viewState.resolution,
+      viewState.rotation,
+      sizeInPixel
+    ),
+    index: 0,
+    layerIndex: 0,
+    layerStatesArray: [],
+    pixelRatio: 1,
+    pixelToCoordinateTransform: [1, 0, 0, 1, 0, 0],
+    postRenderFunctions: [],
+    size: sizeInPixel,
+    time: Date.now(),
+    usedTiles: {},
+    viewState: viewState,
+    viewHints: [0, 0],
+    wantedTiles: {},
+    tileQueue: null, // tile queue is created for each layer
+  };
+}
+
+/**
+ * Returns the map canvas size in pixels based on size units and dpi given in spec
+ * @param {import('../main/index').PrintSpec} spec
+ * @return {[number, number]}
+ */
+export function calculateSizeInPixel(spec) {
+  const { size, dpi } = spec;
+  if (!size[2] || size[2] === 'px') {
+    return [size[0], size[1]];
+  }
+  let pixelX;
+  let pixelY;
+  const unit = size[2];
+
+  switch (unit) {
+    case 'in':
+      pixelX = dpi * size[0];
+      pixelY = dpi * size[1];
+      break;
+    case 'cm':
+      pixelX = (dpi * size[0]) / CM_PER_INCH;
+      pixelY = (dpi * size[1]) / CM_PER_INCH;
+      break;
+    case 'mm':
+      pixelX = (dpi * size[0]) / (CM_PER_INCH * 10);
+      pixelY = (dpi * size[1]) / (CM_PER_INCH * 10);
+      break;
+    case 'm':
+      pixelX = (dpi * size[0] * 100) / CM_PER_INCH;
+      pixelY = (dpi * size[1] * 100) / CM_PER_INCH;
+      break;
+    default:
+      pixelX = size[0];
+      pixelY = size[1];
+  }
+
+  return [Math.round(pixelX), Math.round(pixelY)];
+}
+
+/**
+ * Adapt a generic OL frame state to work with a specific layer
  * @param {import('ol/PluggableMap').FrameState} rootFrameState
  * @param {import('ol/layer/Layer').default} layer
  * @param {number} [opacity] Opacity (0 to 1), 1 if not defined
  * @return {import('ol/PluggableMap').FrameState}
  */
-export function setFrameState(rootFrameState, layer, opacity) {
-  return {
+export function makeLayerFrameState(rootFrameState, layer, opacity) {
+  let fakeTime = 0;
+  let frameState = {
     ...rootFrameState,
     layerStatesArray: [
       {
@@ -43,7 +148,25 @@ export function setFrameState(rootFrameState, layer, opacity) {
         zIndex: 0,
       },
     ],
+    // this is used to make sure that tile transitions are skipped
+    // TODO: remove this once the reprojected tile transitions are fixed in OL
+    get time() {
+      fakeTime += 10000;
+      return fakeTime;
+    },
   };
+  frameState.tileQueue = new TileQueue(
+    (tile, tileSourceKey, tileCenter, tileResolution) =>
+      tilePriorityFunction(
+        frameState,
+        tile,
+        tileSourceKey,
+        tileCenter,
+        tileResolution
+      ),
+    () => {}
+  );
+  return frameState;
 }
 
 /**

--- a/src/worker/polyfills.js
+++ b/src/worker/polyfills.js
@@ -33,11 +33,12 @@ class Image extends OffscreenCanvas {
     fetch(url)
       .then((response) => response.blob())
       .then((blob) => {
+        return createImageBitmap(blob);
+      })
+      .then((imageData) => {
         const ctx = this.getContext('2d');
-        createImageBitmap(blob).then((imageData) => {
-          ctx.drawImage(imageData, 0, 0);
-          this.loadPromiseResolver();
-        });
+        ctx.drawImage(imageData, 0, 0);
+        return this.loadPromiseResolver();
       })
       .catch(this.loadPromiseRejecter);
   }
@@ -46,9 +47,14 @@ class Image extends OffscreenCanvas {
   }
 
   // this is to sort of comply with the HTMLImage API
+  /**
+   * @param {'load'|'error'} eventName
+   * @param {function(): void} callback
+   */
   addEventListener(eventName, callback) {
     if (eventName === 'load') {
-      this.loadPromise.then(callback);
+      // error can be silenced since we can catch it with the 'error' event
+      this.loadPromise.then(callback).catch(() => {});
     } else if (eventName === 'error') {
       this.loadPromise.catch(callback);
     }

--- a/test/unit/printer/job.test.js
+++ b/test/unit/printer/job.test.js
@@ -2,13 +2,15 @@ import { BehaviorSubject, of } from 'rxjs';
 import { createJob } from '../../../src/printer/job';
 import * as LayersMock from '../../../src/printer/layers';
 import { messageToMain } from '../../../src/printer/exchange';
-import * as UtilsMock from '../../../src/printer/utils';
 import { MESSAGE_JOB_STATUS } from '../../../src/shared/constants';
 import * as olDomMock from 'ol/dom';
 
 jest.mock('../../../src/printer/layers');
 jest.mock('../../../src/printer/exchange');
-jest.mock('../../../src/printer/utils');
+jest.mock('../../../src/printer/utils', () => ({
+  ...jest.requireActual('../../../src/printer/utils'),
+  canvasToBlob: jest.fn(() => mockCanvasToBlob()),
+}));
 jest.mock('ol/dom');
 
 const spec = {
@@ -43,7 +45,7 @@ LayersMock.createLayer = jest.fn(() => {
   return layer$;
 });
 
-UtilsMock.canvasToBlob = jest.fn(() => of({ blob: true }));
+const mockCanvasToBlob = () => of({ blob: true });
 
 olDomMock.createCanvasContext2D = jest.fn(() => {
   return {


### PR DESCRIPTION
Fixes #37 

Obviously, to have correct status reports we need to create a new tile queue per layer, otherwise the remaining tiles computation will always be broken. The frame state creation logic has been reworked and hopefully simplified, and now each layer get its own tile queue when calling `makeLayerFrameState`.

This should also make layer loading faster as each tile queue will load tiles separately.

Other things in this PR:
* fixed a situation where the worker would sometimes send updates to the wrong client (e.g. when several tabs on the same page are opened)
* fixed a minor typo in type definitions
* make it so that an image decoding error (i.e. when receiving an XML error on a tile image request) does not break the whole job because of an unhandled promise rejection in the worker