### PR TITLE
Fix print jobs incorrectly marked as finished even though some layers were not

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ A `Layer` object describes a layer in the printed map.
 
 | field | type | description |
 |---|---|---|
-| `type` | `string` | Either `XYZ`, `WMTS`, `WMS` or `WFS`. |
+| `type` | `string` | Either `XYZ`, `WMTS`, `WMS`, `WFS` or `GeoJSON`. |
 | `url` | `string` | URL or URL template for the layer; for XYZ layers, a URL can contain the following tokens: `{a-d}` for randomly choosing a letter, `{x}`, `{y}` and `{z}`. |
 | `opacity` | `number` | Opacity, from 0 (hidden) to 1 (visible). |
 | `attribution` | `string` | Attribution for the data present in the layer. |
@@ -178,6 +178,15 @@ Additional options for `WFS` layer type.
 | `layer` | `string` | Layer name. |
 | `version` | `string` | Version of WFS protocol used: `1.0.0`, `1.1.0` (default) or `2.0.0`. |
 | `format` | `string` | Format used when querying WFS, `gml` (default) or `geojson`. inkmap determines the GML parser based on the WFS version used. |
+| `style` | `object` | JSON object in geostyler notation, defining the layer style. |
+
+#### `GeoJSON layer` type
+
+Additional options for `GeoJSON` layer type.
+
+| field | type | description |
+|---|---|---|
+| `geojson` | `object` | Feature collection in GeoJSON format; coordinates are expected to be in the print job reference system. |
 | `style` | `object` | JSON object in geostyler notation, defining the layer style. |
 
 #### `projectionDefinition` type

--- a/__mocks__/geostyler-openlayers-parser.js
+++ b/__mocks__/geostyler-openlayers-parser.js
@@ -1,0 +1,6 @@
+export default class OpenLayersParser {
+  // returns an empty style after 10ms
+  writeStyle() {
+    return new Promise(resolve => setTimeout(resolve, 10))
+  }
+}

--- a/__mocks__/ol/layer/Vector.js
+++ b/__mocks__/ol/layer/Vector.js
@@ -1,3 +1,5 @@
 import LayerMock from './base';
 
-export default class VectorLayerMock extends LayerMock {}
+export default class VectorLayerMock extends LayerMock {
+  setStyle() { return this; }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,7 +46,7 @@ export { downloadBlob } from './utils';
 /**
  * @typedef {Object} GeoJSONLayer
  * @property {'GeoJSON'} type
- * @property {Object} geojson GeoJSON object
+ * @property {Object} geojson Feature collection in GeoJSON format; coordinates are expected to be in the print job reference system
  * @property {Object} style JSON object in geostyler notation, defining the layer style.
  * @property {string} [attribution] Attribution for the data used in the layer
  */

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -92,7 +92,8 @@ export async function createJob(spec) {
           const rawProgress =
             layerStates.reduce((prev, [progress]) => progress + prev, 0) /
             layerStates.length;
-          const progress = parseFloat(rawProgress.toFixed(4)); // only keep 4 digits precision
+          // only keep 4 digits precision for readability
+          const progress = Math.min(0.999, parseFloat(rawProgress.toFixed(4)));
 
           return of([progress, null, sourceLoadErrors]);
         }

--- a/src/printer/layers.js
+++ b/src/printer/layers.js
@@ -314,6 +314,11 @@ function createLayerWMTS(jobId, layerSpec, rootFrameState) {
   );
 }
 
+/**
+ * @param {import('../main/index').GeoJSONLayer} layerSpec
+ * @param {import('ol/PluggableMap').FrameState} rootFrameState
+ * @return {import('rxjs').Observable<LayerPrintStatus>}
+ */
 function createLayerGeoJSON(layerSpec, rootFrameState) {
   const width = rootFrameState.size[0];
   const height = rootFrameState.size[1];

--- a/test/unit/printer/job.test.js
+++ b/test/unit/printer/job.test.js
@@ -123,7 +123,7 @@ describe('job creation', () => {
 
   describe('with 100 layers', () => {
     beforeEach(() => {
-      const layers = new Array(30).fill(0).map((v, i) => ({
+      const layers = new Array(100).fill(0).map((v, i) => ({
         type: 'XYZ',
         url: `https://my.url-${i}/z/y/x.png`,
       }));

--- a/test/unit/printer/job.test.js
+++ b/test/unit/printer/job.test.js
@@ -57,59 +57,93 @@ describe('job creation', () => {
   beforeEach(() => {
     layerSubjects = [];
     jest.clearAllMocks();
-    createJob(spec);
   });
 
-  it('creates the correct amount of layers', () => {
-    expect(LayersMock.createLayer).toHaveBeenCalledTimes(3);
-  });
-  it('creates the correct canvas size from cm', () => {
-    expect(olDomMock.createCanvasContext2D).toHaveBeenLastCalledWith(630, 315);
-  });
-  it('broadcasts initial status to the main thread', () => {
-    expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
-      status: {
-        id: expect.any(Number),
-        imageBlob: null,
-        progress: 0,
-        spec,
-        status: 'ongoing',
-        sourceLoadErrors: [],
-      },
+  describe('with 3 layers', () => {
+    beforeEach(() => {
+      createJob(spec);
+    });
+
+    it('creates the correct amount of layers', () => {
+      expect(LayersMock.createLayer).toHaveBeenCalledTimes(3);
+    });
+    it('creates the correct canvas size from cm', () => {
+      expect(olDomMock.createCanvasContext2D).toHaveBeenLastCalledWith(
+        630,
+        315
+      );
+    });
+    it('broadcasts initial status to the main thread', () => {
+      expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
+        status: {
+          id: expect.any(Number),
+          imageBlob: null,
+          progress: 0,
+          spec,
+          status: 'ongoing',
+          sourceLoadErrors: [],
+        },
+      });
+    });
+    it('broadcast advancement status', () => {
+      layerSubjects[0].next([0.1, null, undefined]);
+      layerSubjects[1].next([0.9, null, undefined]);
+      layerSubjects[2].next([0.2, null, undefined]);
+      expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
+        status: {
+          id: expect.any(Number),
+          imageBlob: null,
+          progress: 0.4,
+          spec,
+          status: 'ongoing',
+          sourceLoadErrors: [],
+        },
+      });
+    });
+    it('prints all layers to a final canvas and passes errorurls to status when finished', () => {
+      layerSubjects[0].next([1, { style: {} }, errorurl]);
+      layerSubjects[1].next([1, { style: {} }]);
+      layerSubjects[2].next([1, { style: {} }]);
+      expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
+        status: {
+          id: expect.any(Number),
+          imageBlob: { blob: true },
+          progress: 1,
+          spec,
+          status: 'finished',
+          sourceLoadErrors: [
+            {
+              url: errorurl,
+            },
+          ],
+        },
+      });
     });
   });
-  it('broadcast advancement status', () => {
-    layerSubjects[0].next([0.1, null, undefined]);
-    layerSubjects[1].next([0.9, null, undefined]);
-    layerSubjects[2].next([0.2, null, undefined]);
-    expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
-      status: {
-        id: expect.any(Number),
-        imageBlob: null,
-        progress: 0.4,
-        spec,
-        status: 'ongoing',
-        sourceLoadErrors: [],
-      },
+
+  describe('with 100 layers', () => {
+    beforeEach(() => {
+      const layers = new Array(30).fill(0).map((v, i) => ({
+        type: 'XYZ',
+        url: `https://my.url-${i}/z/y/x.png`,
+      }));
+      createJob({ ...spec, layers });
     });
-  });
-  it('prints all layers to a final canvas and passes errorurls to status when finished', () => {
-    layerSubjects[0].next([1, { style: {} }, errorurl]);
-    layerSubjects[1].next([1, { style: {} }]);
-    layerSubjects[2].next([1, { style: {} }]);
-    expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
-      status: {
-        id: expect.any(Number),
-        imageBlob: { blob: true },
-        progress: 1,
-        spec,
-        status: 'finished',
-        sourceLoadErrors: [
-          {
-            url: errorurl,
-          },
-        ],
-      },
+
+    it('does not broadcast a print success if all layers except one are complete', () => {
+      layerSubjects.forEach((subject, index) =>
+        subject.next(index > 0 ? [1, { style: {} }] : [0.999, null, undefined])
+      );
+      expect(messageToMain).toHaveBeenLastCalledWith(MESSAGE_JOB_STATUS, {
+        status: {
+          id: expect.any(Number),
+          imageBlob: null,
+          progress: 0.999,
+          spec: expect.any(Object),
+          status: 'ongoing',
+          sourceLoadErrors: [],
+        },
+      });
     });
   });
 });

--- a/test/unit/printer/layers.test.js
+++ b/test/unit/printer/layers.test.js
@@ -349,11 +349,6 @@ describe('layer creation', () => {
       type: 'GeoJSON',
       geojson: {
         type: 'FeatureCollection',
-        name: 'france_3857',
-        crs: {
-          type: 'name',
-          properties: { name: 'urn:ogc:def:crs:EPSG::3857' },
-        },
         features: [],
       },
       style: {},

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,3 @@
+export function waitForPromises() {
+  return new Promise((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
This was due to an oversight in progress rounding logic. Added a failing test fixed by this change.

Also added unrelated unit tests for the new GeoJSON layer that was added in #42 and #44.