### PR TITLE
Add printing of layer legends

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ A `minimumWidth` (e.g. `[80, 'mm']`) can be provided to request a smaller or lar
 
 > Note that for this scale bar to be relevant in a printed document, its real-world size **has** to be respected.
 
+#### `createLegend(jsonSpec: PrintSpec): Promise<Blob>`
+
+Takes in a [`PrintSpec`](#printspec-type) object and returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which resolves to a Blob containing the final legend image.
+
 #### `PrintSpec` type
 
 A `PrintSpec` object describes the content and aspect of the map to be printed.

--- a/demo/elements/print-spec.js
+++ b/demo/elements/print-spec.js
@@ -2,7 +2,7 @@ import PresetSpecs from '../preset-specs';
 
 const PresetSpecsNames = Object.keys(PresetSpecs);
 
-class PrintSpec extends HTMLElement {
+class PrintSpecEditor extends HTMLElement {
   constructor() {
     super();
 
@@ -167,4 +167,4 @@ class PrintSpec extends HTMLElement {
   }
 }
 
-customElements.define('print-spec', PrintSpec);
+customElements.define('print-spec', PrintSpecEditor);

--- a/demo/examples/01-simple.js
+++ b/demo/examples/01-simple.js
@@ -2,7 +2,7 @@ import { downloadBlob, print } from '@camptocamp/inkmap';
 
 const root = document.getElementById('example-01');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => (btn.enabled = valid));

--- a/demo/examples/02-progress.js
+++ b/demo/examples/02-progress.js
@@ -3,7 +3,7 @@ import { downloadBlob, getJobStatus, queuePrint } from '@camptocamp/inkmap';
 const root = document.getElementById('example-02');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
 const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => (btn.enabled = valid));

--- a/demo/examples/03-cancel.js
+++ b/demo/examples/03-cancel.js
@@ -8,7 +8,7 @@ import {
 const root = document.getElementById('example-03');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
 const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 const btnCancel = /** @type {Button} */ root.querySelector('.cancel-btn');
 
 // make sure the spec is valid to allow printing

--- a/demo/examples/04-jobs.js
+++ b/demo/examples/04-jobs.js
@@ -8,7 +8,7 @@ import {
 const root = document.getElementById('example-04');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
 const bars = /** @type {ProgressBars} */ root.querySelector('progress-bars');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => (btn.enabled = valid));

--- a/demo/examples/05-pdf.js
+++ b/demo/examples/05-pdf.js
@@ -4,7 +4,7 @@ import { getScaleBar } from '../../src/main';
 
 const root = document.getElementById('example-05');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => (btn.enabled = valid));

--- a/demo/examples/06-projection.js
+++ b/demo/examples/06-projection.js
@@ -2,7 +2,7 @@ import { downloadBlob, print, registerProjection } from '@camptocamp/inkmap';
 
 const root = document.getElementById('example-06');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => (btn.enabled = valid));

--- a/demo/examples/07-errors.js
+++ b/demo/examples/07-errors.js
@@ -2,7 +2,7 @@ import { downloadBlob, getJobStatus, queuePrint } from '@camptocamp/inkmap';
 
 const root = document.getElementById('example-07');
 const btn = /** @type {CustomButton} */ root.querySelector('custom-button');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 const errors = root.querySelector('#errors');
 
 // make sure the spec is valid to allow printing

--- a/demo/examples/08-legends.js
+++ b/demo/examples/08-legends.js
@@ -39,6 +39,6 @@ mapBtn.addEventListener('click', async () => {
 });
 
 legendBtn.addEventListener('click', async () => {
-  const blob = await createLegends(spec);
+  const blob = await createLegends(spec.value);
   downloadBlob(blob, 'legend.svg');
 });

--- a/demo/examples/08-legends.js
+++ b/demo/examples/08-legends.js
@@ -10,7 +10,7 @@ const legendBtn = /** @type {CustomButton} */ root.querySelector(
 );
 root.querySelector('custom-button.legend-btn');
 const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
-const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+const spec = /** @type {PrintSpecEditor} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => {

--- a/demo/examples/08-legends.js
+++ b/demo/examples/08-legends.js
@@ -2,16 +2,20 @@ import { downloadBlob, getJobStatus, queuePrint } from '@camptocamp/inkmap';
 import { createLegends } from '../../src/main';
 
 const root = document.getElementById('example-08');
-const mapBtn = /** @type {CustomButton} */ root.querySelector("custom-button.map-btn")
-const legendBtn = /** @type {CustomButton} */ root.querySelector("custom-button.legend-btn")
-root.querySelector("custom-button.legend-btn")
+const mapBtn = /** @type {CustomButton} */ root.querySelector(
+  'custom-button.map-btn'
+);
+const legendBtn = /** @type {CustomButton} */ root.querySelector(
+  'custom-button.legend-btn'
+);
+root.querySelector('custom-button.legend-btn');
 const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
 const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
 
 // make sure the spec is valid to allow printing
 spec.onValidityCheck((valid) => {
   mapBtn.enabled = valid;
-  legendBtn.enabled = valid
+  legendBtn.enabled = valid;
 });
 
 mapBtn.addEventListener('click', async () => {
@@ -35,7 +39,6 @@ mapBtn.addEventListener('click', async () => {
       downloadBlob(printStatus.imageBlob, 'inkmap.png');
     }
   });
-
 });
 
 legendBtn.addEventListener('click', async () => {

--- a/demo/examples/08-legends.js
+++ b/demo/examples/08-legends.js
@@ -1,0 +1,44 @@
+import { downloadBlob, getJobStatus, queuePrint } from '@camptocamp/inkmap';
+import { createLegends } from '../../src/main';
+
+const root = document.getElementById('example-08');
+const mapBtn = /** @type {CustomButton} */ root.querySelector("custom-button.map-btn")
+const legendBtn = /** @type {CustomButton} */ root.querySelector("custom-button.legend-btn")
+root.querySelector("custom-button.legend-btn")
+const bar = /** @type {CustomProgress} */ root.querySelector('custom-progress');
+const spec = /** @type {PrintSpec} */ root.querySelector('print-spec');
+
+// make sure the spec is valid to allow printing
+spec.onValidityCheck((valid) => {
+  mapBtn.enabled = valid;
+  legendBtn.enabled = valid
+});
+
+mapBtn.addEventListener('click', async () => {
+  mapBtn.showSpinner();
+
+  // display the job progress
+  bar.progress = 0;
+  bar.status = 'pending';
+
+  // create a job, get a promise that resolves with the job id
+  const jobId = await queuePrint(spec.value);
+
+  getJobStatus(jobId).subscribe((printStatus) => {
+    // update the job progress
+    bar.progress = printStatus.progress;
+    bar.status = printStatus.status;
+
+    // job is finished
+    if (printStatus.progress === 1) {
+      mapBtn.hideSpinner();
+      downloadBlob(printStatus.imageBlob, 'inkmap.png');
+    }
+  });
+
+});
+
+legendBtn.addEventListener('click', async () => {
+  const blob = await createLegends(spec);
+  downloadBlob(blob, 'legend.svg');
+});

--- a/demo/index.html
+++ b/demo/index.html
@@ -384,7 +384,8 @@
           GeoJSON and WFS layers.
         </p>
         <p>
-          The print will generate a separate image containing all the legends at once.
+          The print will generate a separate image containing all the legends at
+          once.
         </p>
         <ul class="nav nav-tabs">
           <li class="nav-item">
@@ -412,7 +413,9 @@
               <div class="col-3">
                 <custom-button class="map-btn"> Generate map </custom-button>
                 <custom-progress></custom-progress>
-                <custom-button class="legend-btn"> Generate legend </custom-button>
+                <custom-button class="legend-btn">
+                  Generate legend
+                </custom-button>
               </div>
             </div>
           </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -374,8 +374,56 @@
         </div>
         <p id="errors" class="text-danger"></p>
       </div>
-    </div>
 
+      <div class="mt-5" id="example-08">
+        <h2>Printing legends</h2>
+        <p>
+          This examples shows how to print legends for vector and rasterlayers
+          by providing the configuration option <code>legend</code> on a layer
+          with a value of <code>true</code>. Currently this supports WMS, WMTS,
+          GeoJSON and WFS layers.
+        </p>
+        <p>
+          The print will generate a separate image containing all the legends at once.
+        </p>
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href=".example-08-result"
+              >Result</a
+            >
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-toggle="tab" href=".example-08-source"
+              >Source</a
+            >
+          </li>
+        </ul>
+        <div class="tab-content mt-2">
+          <div class="tab-pane example-08-result show active">
+            <div class="row align-items-start">
+              <print-spec
+                class="col-8"
+                expanded="false"
+                select="Spec with legends"
+              ></print-spec>
+              <div class="col-3">
+                <custom-button class="map-btn"> Generate map </custom-button>
+                <custom-progress></custom-progress>
+                <custom-button class="legend-btn"> Generate legend </custom-button>
+              </div>
+            </div>
+          </div>
+          <div class="tab-pane example-08-source">
+            <pre
+              class="rounded small"
+            ><code class="js"><%- example08 %></code></pre>
+          </div>
+        </div>
+      </div>
+    </div>
     <script src="app.js"></script>
   </body>
 </html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -9,5 +9,6 @@ import './examples/04-jobs';
 import './examples/05-pdf';
 import './examples/06-projection';
 import './examples/07-errors';
+import './examples/08-legends';
 
 hljs.initHighlightingOnLoad();

--- a/demo/preset-specs.js
+++ b/demo/preset-specs.js
@@ -339,7 +339,7 @@ const OsmWmsSpec = {
       url: 'https://ows.mundialis.de/services/service',
       layer: 'OSM-WMS',
       tiled: true,
-      attribution: '© OpenStreetMap (www.openstreetmap.org), Terrestris GmbH',
+      attribution: '© OpenStreetMap (www.openstreetmap.org), terrestris GmbH',
     },
   ],
   size: [400, 240, 'mm'],
@@ -640,6 +640,56 @@ const CustomProjection = {
   attributions: 'bottom-right',
 };
 
+const LegendSpec = {
+  layers: [
+    {
+      type: 'WMS',
+      url: 'https://ows.terrestris.de/osm/service',
+      layer: 'OSM-WMS',
+      tiled: true,
+      legend: true,
+      attribution: '© OpenStreetMap (www.openstreetmap.org), terrestris GmbH',
+    },
+    {
+      type: "WFS",
+      url: "https://ows-demo.terrestris.de/geoserver/osm/wfs?maxFeatures=50",
+      layer: "osm:osm-fuel",
+      format: "geojson",
+      version: "1.1.0",
+      legend: true,
+      style: {
+        name: "WFS Style",
+        rules: [
+          {
+            name: "Simple symbol",
+            symbolizers: [
+              {
+                kind: "Mark",
+                wellKnownName: "x",
+                opacity: 0.7,
+                radius: 10,
+                color: '#ff0000'
+              }
+            ]
+          }
+        ]
+      }
+    },
+    OsmAndGeoJSONSpec.layers[1]
+  ],
+  size: [400, 300, 'mm'],
+  center: [3, 46.5],
+  dpi: 72,
+  scale: 7000000,
+  scaleBar: {
+    position: 'bottom-left',
+    units: 'metric',
+  },
+  projection: 'EPSG:3857',
+  northArrow: 'top-right',
+  attributions: 'bottom-right',
+};
+
 export const ErrorSpec = {
   layers: [
     {
@@ -647,7 +697,7 @@ export const ErrorSpec = {
       url: 'https://ows.mundialis.de/services/service',
       layer: 'TOPO-OSM-WMS',
       tiled: true,
-      attribution: '© OpenStreetMap, Natural Earth, Terrestris GmbH',
+      attribution: '© OpenStreetMap, Natural Earth, terrestris GmbH',
     },
     {
       type: 'WMS',
@@ -688,6 +738,7 @@ const PresetSpecs = {
   'WFS layer example': WfsSpec,
   'Custom local projection (WMS)': CustomProjection,
   'Spec with invalid sources': ErrorSpec,
+  'Spec with legends': LegendSpec
 };
 
 export default PresetSpecs;

--- a/demo/preset-specs.js
+++ b/demo/preset-specs.js
@@ -651,31 +651,31 @@ const LegendSpec = {
       attribution: '© OpenStreetMap (www.openstreetmap.org), terrestris GmbH',
     },
     {
-      type: "WFS",
-      url: "https://ows-demo.terrestris.de/geoserver/osm/wfs?maxFeatures=50",
-      layer: "osm:osm-fuel",
-      format: "geojson",
-      version: "1.1.0",
+      type: 'WFS',
+      url: 'https://ows-demo.terrestris.de/geoserver/osm/wfs?maxFeatures=50',
+      layer: 'osm:osm-fuel',
+      format: 'geojson',
+      version: '1.1.0',
       legend: true,
       style: {
-        name: "WFS Style",
+        name: 'WFS Style',
         rules: [
           {
-            name: "Simple symbol",
+            name: 'Simple symbol',
             symbolizers: [
               {
-                kind: "Mark",
-                wellKnownName: "x",
+                kind: 'Mark',
+                wellKnownName: 'x',
                 opacity: 0.7,
                 radius: 10,
-                color: '#ff0000'
-              }
-            ]
-          }
-        ]
-      }
+                color: '#ff0000',
+              },
+            ],
+          },
+        ],
+      },
     },
-    OsmAndGeoJSONSpec.layers[1]
+    OsmAndGeoJSONSpec.layers[1],
   ],
   size: [400, 300, 'mm'],
   center: [3, 46.5],
@@ -738,7 +738,7 @@ const PresetSpecs = {
   'WFS layer example': WfsSpec,
   'Custom local projection (WMS)': CustomProjection,
   'Spec with invalid sources': ErrorSpec,
-  'Spec with legends': LegendSpec
+  'Spec with legends': LegendSpec,
 };
 
 export default PresetSpecs;

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -23,6 +23,9 @@ const example06 = fs.readFileSync(
 const example07 = fs.readFileSync(
   path.resolve(__dirname, 'examples/07-errors.js')
 );
+const example08 = fs.readFileSync(
+  path.resolve(__dirname, 'examples/08-legends.js')
+);
 
 module.exports = {
   mode: 'development',
@@ -51,6 +54,7 @@ module.exports = {
         example05,
         example06,
         example07,
+        example08,
       },
       inject: false,
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "geostyler-legend": "^2.2.0",
         "geostyler-openlayers-parser": "^2.1.0",
         "ol": "^6.5.0",
         "proj4": "^2.6.3",
@@ -24,6 +25,7 @@
         "eslint": "^7.12.1",
         "eslint-config-prettier": "^6.15.0",
         "html-webpack-plugin": "^4.5.0",
+        "isomorphic-fetch": "^3.0.0",
         "jest": "^26.6.1",
         "jest-canvas-mock": "^2.3.1",
         "jspdf": "^2.2.0",
@@ -4402,6 +4404,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.2.tgz",
+      "integrity": "sha512-d29EDd0iUBrRoKhPndhDY6U/PYxOWqgIZwKTooy2UkBfU7TNZNpRho0yLWPxlatQrFWk2mnTu71IZQ4+LRgKlQ=="
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -6747,10 +6754,179 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "node_modules/d3": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+      "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2",
+        "d3-axis": "2",
+        "d3-brush": "2",
+        "d3-chord": "2",
+        "d3-color": "2",
+        "d3-contour": "2",
+        "d3-delaunay": "5",
+        "d3-dispatch": "2",
+        "d3-drag": "2",
+        "d3-dsv": "2",
+        "d3-ease": "2",
+        "d3-fetch": "2",
+        "d3-force": "2",
+        "d3-format": "2",
+        "d3-geo": "2",
+        "d3-hierarchy": "2",
+        "d3-interpolate": "2",
+        "d3-path": "2",
+        "d3-polygon": "2",
+        "d3-quadtree": "2",
+        "d3-random": "2",
+        "d3-scale": "3",
+        "d3-scale-chromatic": "2",
+        "d3-selection": "2",
+        "d3-shape": "2",
+        "d3-time": "2",
+        "d3-time-format": "3",
+        "d3-timer": "2",
+        "d3-transition": "2",
+        "d3-zoom": "2"
+      }
+    },
     "node_modules/d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-axis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+      "peer": true
+    },
+    "node_modules/d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+      "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "peer": true
+    },
+    "node_modules/d3-contour": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+      "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-contour/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "peer": true,
+      "dependencies": {
+        "delaunator": "4"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "peer": true
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "peer": true,
+      "dependencies": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json",
+        "csv2tsv": "bin/dsv2dsv",
+        "dsv2dsv": "bin/dsv2dsv",
+        "dsv2json": "bin/dsv2json",
+        "json2csv": "bin/json2dsv",
+        "json2dsv": "bin/json2dsv",
+        "json2tsv": "bin/json2dsv",
+        "tsv2csv": "bin/dsv2dsv",
+        "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "peer": true
+    },
+    "node_modules/d3-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+      "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "1 - 2"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "peer": true
     },
     "node_modules/d3-geo": {
       "version": "1.7.1",
@@ -6760,10 +6936,176 @@
         "d3-array": "1"
       }
     },
+    "node_modules/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "peer": true
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "peer": true
+    },
+    "node_modules/d3-polygon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+      "peer": true
+    },
+    "node_modules/d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+      "peer": true
+    },
+    "node_modules/d3-random": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==",
+      "peer": true
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-interpolate": "1 - 2"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
+    },
+    "node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "peer": true,
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-time/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "peer": true
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
     "node_modules/d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -6955,6 +7297,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "peer": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -8739,6 +9087,43 @@
         "rbush": "*"
       }
     },
+    "node_modules/geostyler-legend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/geostyler-legend/-/geostyler-legend-2.2.0.tgz",
+      "integrity": "sha512-M+xgzPd5M1IWN4V8KsAvbiP2fgXXQRxqndhgwYmlLYjRRLYsJmpvT8pF6LrVNZ9xRBxT6UCBHMUQtz635HKuFg==",
+      "dependencies": {
+        "@types/d3-selection": "^3.0.1",
+        "geostyler-openlayers-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "d3": "^6.7.0",
+        "ol": "^6.5.0"
+      }
+    },
+    "node_modules/geostyler-legend/node_modules/geostyler-openlayers-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "dependencies": {
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/geostyler-legend/node_modules/geostyler-style": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/geostyler-openlayers-parser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.1.0.tgz",
@@ -9509,6 +9894,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "peer": true
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -9928,6 +10319,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
       }
     },
     "node_modules/isstream": {
@@ -12689,9 +13090,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -17884,6 +18285,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -22167,6 +22574,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/d3-selection": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.2.tgz",
+      "integrity": "sha512-d29EDd0iUBrRoKhPndhDY6U/PYxOWqgIZwKTooy2UkBfU7TNZNpRho0yLWPxlatQrFWk2mnTu71IZQ4+LRgKlQ=="
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -24170,10 +24582,190 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "d3": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+      "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+      "peer": true,
+      "requires": {
+        "d3-array": "2",
+        "d3-axis": "2",
+        "d3-brush": "2",
+        "d3-chord": "2",
+        "d3-color": "2",
+        "d3-contour": "2",
+        "d3-delaunay": "5",
+        "d3-dispatch": "2",
+        "d3-drag": "2",
+        "d3-dsv": "2",
+        "d3-ease": "2",
+        "d3-fetch": "2",
+        "d3-force": "2",
+        "d3-format": "2",
+        "d3-geo": "2",
+        "d3-hierarchy": "2",
+        "d3-interpolate": "2",
+        "d3-path": "2",
+        "d3-polygon": "2",
+        "d3-quadtree": "2",
+        "d3-random": "2",
+        "d3-scale": "3",
+        "d3-scale-chromatic": "2",
+        "d3-selection": "2",
+        "d3-shape": "2",
+        "d3-time": "2",
+        "d3-time-format": "3",
+        "d3-timer": "2",
+        "d3-transition": "2",
+        "d3-zoom": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "peer": true,
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        },
+        "d3-geo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+          "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+          "peer": true,
+          "requires": {
+            "d3-array": "^2.5.0"
+          }
+        }
+      }
+    },
     "d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-axis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+      "peer": true
+    },
+    "d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "peer": true,
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "d3-chord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+      "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "peer": true,
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "peer": true
+    },
+    "d3-contour": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+      "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "peer": true,
+      "requires": {
+        "d3-array": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "peer": true,
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        }
+      }
+    },
+    "d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "peer": true,
+      "requires": {
+        "delaunator": "4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "peer": true
+    },
+    "d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "peer": true,
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "peer": true,
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      }
+    },
+    "d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "peer": true
+    },
+    "d3-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+      "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+      "peer": true,
+      "requires": {
+        "d3-dsv": "1 - 2"
+      }
+    },
+    "d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "peer": true,
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "peer": true
     },
     "d3-geo": {
       "version": "1.7.1",
@@ -24183,10 +24775,159 @@
         "d3-array": "1"
       }
     },
+    "d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "peer": true
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "peer": true,
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "peer": true
+    },
+    "d3-polygon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+      "peer": true
+    },
+    "d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+      "peer": true
+    },
+    "d3-random": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==",
+      "peer": true
+    },
+    "d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "peer": true,
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "peer": true,
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        }
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "peer": true,
+      "requires": {
+        "d3-color": "1 - 2",
+        "d3-interpolate": "1 - 2"
+      }
+    },
+    "d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
+    },
+    "d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "peer": true,
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "peer": true,
+      "requires": {
+        "d3-array": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "peer": true,
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        }
+      }
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "peer": true,
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "peer": true
+    },
+    "d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "peer": true,
+      "requires": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
     "d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "peer": true,
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -24332,6 +25073,12 @@
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
       }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "peer": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -25773,6 +26520,35 @@
         "rbush": "*"
       }
     },
+    "geostyler-legend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/geostyler-legend/-/geostyler-legend-2.2.0.tgz",
+      "integrity": "sha512-M+xgzPd5M1IWN4V8KsAvbiP2fgXXQRxqndhgwYmlLYjRRLYsJmpvT8pF6LrVNZ9xRBxT6UCBHMUQtz635HKuFg==",
+      "requires": {
+        "@types/d3-selection": "^3.0.1",
+        "geostyler-openlayers-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "geostyler-openlayers-parser": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+          "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+          "requires": {
+            "geostyler-style": "^5.0.2",
+            "lodash": "^4.17.21"
+          }
+        },
+        "geostyler-style": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+          "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+          "requires": {
+            "@types/lodash": "^4.14.168",
+            "lodash": "^4.17.21"
+          }
+        }
+      }
+    },
     "geostyler-openlayers-parser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.1.0.tgz",
@@ -26390,6 +27166,12 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "peer": true
+    },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -26695,6 +27477,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -28786,9 +29578,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -33056,6 +33848,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "geostyler-legend": "^2.2.0",
-        "geostyler-openlayers-parser": "^2.1.0",
+        "geostyler-openlayers-parser": "^2.5.0",
         "ol": "^6.5.0",
         "proj4": "^2.6.3",
         "rxjs": "^6.6.3"
@@ -3001,45 +3001,45 @@
       }
     },
     "node_modules/@terrestris/base-util": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-0.2.4.tgz",
-      "integrity": "sha512-HupxqYZvwAaQohBnwJizusNTCPuAaxlYU5HS62xk7axnz6VA6zqnD/oB5ycXpgqNTFSrMBuqlCXuDJx1oS+PZw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-1.0.1.tgz",
+      "integrity": "sha512-ML1IaqZXGWlXrI8pEAnGZv6qPmW72uBZkbc5NvZcBDattpXmrE3rCntTou1t/zLaOz0v4qmG5KORMTSzOeScRQ==",
       "dependencies": {
-        "@types/lodash": "^4.14.138",
+        "@types/lodash": "^4.14.168",
         "@types/loglevel": "^1.6.3",
         "@types/url-parse": "^1.4.3",
         "@types/url-search-params": "^1.1.0",
-        "@types/validator": "^13.0.0",
-        "lodash": "^4.17.15",
-        "loglevel": "^1.6.3",
-        "query-string": "^6.8.2",
+        "@types/validator": "^13.1.3",
+        "lodash": "^4.17.20",
+        "loglevel": "^1.7.1",
+        "query-string": "^6.13.8",
         "url-parse": "^1.4.7",
         "url-search-params": "^1.1.0",
-        "validator": "^13.0.0"
+        "validator": "^13.5.2"
       }
     },
     "node_modules/@terrestris/ol-util": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.0.2.tgz",
-      "integrity": "sha512-YI+rdUB+iuH2V50pCQzdsf9Q0Df+efLSh5HpyMRRxGHNTBwTLZWsO+ZZhmQbsYaTuFKeeC1TjQQTsLbJCGOhLg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
       "dependencies": {
-        "@terrestris/base-util": "^0.2.2",
+        "@terrestris/base-util": "^1.0.0",
         "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.15",
-        "proj4": "^2.6.0",
-        "shpjs": "^3.4.3"
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
       },
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "ol": "~6.0"
+        "ol": "~6.5"
       }
     },
     "node_modules/@turf/along": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -3050,7 +3050,7 @@
     "node_modules/@turf/area": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3059,7 +3059,7 @@
     "node_modules/@turf/bbox": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3068,7 +3068,7 @@
     "node_modules/@turf/bbox-clip": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3078,7 +3078,7 @@
     "node_modules/@turf/bbox-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3086,7 +3086,7 @@
     "node_modules/@turf/bearing": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3095,7 +3095,7 @@
     "node_modules/@turf/bezier-spline": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3104,7 +3104,7 @@
     "node_modules/@turf/boolean-clockwise": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3113,7 +3113,7 @@
     "node_modules/@turf/boolean-contains": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -3125,7 +3125,7 @@
     "node_modules/@turf/boolean-crosses": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3149,7 +3149,7 @@
     "node_modules/@turf/boolean-equal": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3160,7 +3160,7 @@
     "node_modules/@turf/boolean-overlap": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3173,7 +3173,7 @@
     "node_modules/@turf/boolean-parallel": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3184,7 +3184,7 @@
     "node_modules/@turf/boolean-point-in-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3193,7 +3193,7 @@
     "node_modules/@turf/boolean-point-on-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3202,7 +3202,7 @@
     "node_modules/@turf/boolean-within": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -3214,7 +3214,7 @@
     "node_modules/@turf/buffer": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -3228,7 +3228,7 @@
     "node_modules/@turf/center": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -3237,7 +3237,7 @@
     "node_modules/@turf/center-mean": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3247,7 +3247,7 @@
     "node_modules/@turf/center-median": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
       "dependencies": {
         "@turf/center-mean": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -3259,7 +3259,7 @@
     "node_modules/@turf/center-of-mass": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
       "dependencies": {
         "@turf/centroid": "^5.1.5",
         "@turf/convex": "^5.1.5",
@@ -3271,7 +3271,7 @@
     "node_modules/@turf/centroid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3280,7 +3280,7 @@
     "node_modules/@turf/circle": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
       "dependencies": {
         "@turf/destination": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -3289,7 +3289,7 @@
     "node_modules/@turf/clean-coords": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3298,7 +3298,7 @@
     "node_modules/@turf/clone": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3306,7 +3306,7 @@
     "node_modules/@turf/clusters": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3315,7 +3315,7 @@
     "node_modules/@turf/clusters-dbscan": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -3328,7 +3328,7 @@
     "node_modules/@turf/clusters-kmeans": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3340,7 +3340,7 @@
     "node_modules/@turf/collect": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -3364,7 +3364,7 @@
     "node_modules/@turf/combine": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3373,7 +3373,7 @@
     "node_modules/@turf/concave": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -3388,7 +3388,7 @@
     "node_modules/@turf/convex": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5",
@@ -3398,7 +3398,7 @@
     "node_modules/@turf/destination": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3407,7 +3407,7 @@
     "node_modules/@turf/difference": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3419,7 +3419,7 @@
     "node_modules/@turf/dissolve": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
       "dependencies": {
         "@turf/boolean-overlap": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -3435,7 +3435,7 @@
     "node_modules/@turf/distance": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3444,7 +3444,7 @@
     "node_modules/@turf/ellipse": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3455,7 +3455,7 @@
     "node_modules/@turf/envelope": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -3465,7 +3465,7 @@
     "node_modules/@turf/explode": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3474,7 +3474,7 @@
     "node_modules/@turf/flatten": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -3483,7 +3483,7 @@
     "node_modules/@turf/flip": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3493,7 +3493,7 @@
     "node_modules/@turf/great-circle": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3502,12 +3502,12 @@
     "node_modules/@turf/helpers": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
     },
     "node_modules/@turf/hex-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3518,7 +3518,7 @@
     "node_modules/@turf/interpolate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -3548,7 +3548,7 @@
     "node_modules/@turf/invariant": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3556,7 +3556,7 @@
     "node_modules/@turf/isobands": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/bbox": "^5.1.5",
@@ -3570,7 +3570,7 @@
     "node_modules/@turf/isolines": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3581,7 +3581,7 @@
     "node_modules/@turf/kinks": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3589,7 +3589,7 @@
     "node_modules/@turf/length": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3599,7 +3599,7 @@
     "node_modules/@turf/line-arc": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
       "dependencies": {
         "@turf/circle": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -3609,7 +3609,7 @@
     "node_modules/@turf/line-chunk": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/length": "^5.1.5",
@@ -3620,7 +3620,7 @@
     "node_modules/@turf/line-intersect": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3632,7 +3632,7 @@
     "node_modules/@turf/line-offset": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3642,7 +3642,7 @@
     "node_modules/@turf/line-overlap": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
       "dependencies": {
         "@turf/boolean-point-on-line": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3656,7 +3656,7 @@
     "node_modules/@turf/line-segment": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3666,7 +3666,7 @@
     "node_modules/@turf/line-slice": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -3676,7 +3676,7 @@
     "node_modules/@turf/line-slice-along": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -3687,7 +3687,7 @@
     "node_modules/@turf/line-split": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3704,7 +3704,7 @@
     "node_modules/@turf/line-to-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3714,7 +3714,7 @@
     "node_modules/@turf/mask": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3739,7 +3739,7 @@
     "node_modules/@turf/meta": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3747,7 +3747,7 @@
     "node_modules/@turf/midpoint": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -3758,7 +3758,7 @@
     "node_modules/@turf/nearest-point": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -3769,7 +3769,7 @@
     "node_modules/@turf/nearest-point-on-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -3793,30 +3793,39 @@
       }
     },
     "node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
     },
     "node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-      "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/planepoint": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3825,7 +3834,7 @@
     "node_modules/@turf/point-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
       "dependencies": {
         "@turf/boolean-within": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -3836,7 +3845,7 @@
     "node_modules/@turf/point-on-feature": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -3861,84 +3870,111 @@
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",
-      "integrity": "sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/clone": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.3.0.tgz",
-      "integrity": "sha512-GAgN89/9GCqUKECB1oY2hcTs0K2rZj+a2tY6VfM0ef9wwckuQZCKi+kKGUzhKVrmHee15jKV8n6DY0er8OndKg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
+      "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
-      "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-      "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/projection": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.3.0.tgz",
-      "integrity": "sha512-IpSs7Q6G6xi47ynVlYYVegPLy6Jc0yo3/DcIm83jaJa4NnzPFXIFZT0v9Fe1N8MraHZqiqaSPbVnJXCGwR12lg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
+      "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
       "dependencies": {
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/clone": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/rhumb-bearing": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.3.0.tgz",
-      "integrity": "sha512-/c/BE3huEUrwN6gx7Bg2FzfJqeU+TWk/slQPDHpbVunlIPbS6L28brqSVD+KXfMG8HQIzynz6Pm4Y+j5Iv4aWA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.5.0.tgz",
+      "integrity": "sha512-jMyqiMRK4hzREjQmnLXmkJ+VTNTx1ii8vuqRwJPcTlKbNWfjDz/5JqJlb5NaFDcdMpftWovkW5GevfnuzHnOYA==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/rhumb-distance": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.3.0.tgz",
-      "integrity": "sha512-wMIQVvznusonnp/POeucFdA4Rubn0NrkcEMdxdcCgFK7OmTz0zU4CEnNONF2IUGkQ5WwoKiuS7MOTQ8OuCjSfQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.5.0.tgz",
+      "integrity": "sha512-oKp8KFE8E4huC2Z1a1KNcFwjVOqa99isxNOwfo4g3SUABQ6NezjKDDrnvC4yI5YZ3/huDjULLBvhed45xdCrzg==",
       "dependencies": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/points-within-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3948,7 +3984,7 @@
     "node_modules/@turf/polygon-tangents": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3957,7 +3993,7 @@
     "node_modules/@turf/polygon-to-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -3966,7 +4002,7 @@
     "node_modules/@turf/polygonize": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/envelope": "^5.1.5",
@@ -3978,7 +4014,7 @@
     "node_modules/@turf/projection": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -3988,7 +4024,7 @@
     "node_modules/@turf/random": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -3996,7 +4032,7 @@
     "node_modules/@turf/rewind": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
       "dependencies": {
         "@turf/boolean-clockwise": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -4008,7 +4044,7 @@
     "node_modules/@turf/rhumb-bearing": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4017,7 +4053,7 @@
     "node_modules/@turf/rhumb-destination": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4026,7 +4062,7 @@
     "node_modules/@turf/rhumb-distance": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4035,7 +4071,7 @@
     "node_modules/@turf/sample": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -4043,7 +4079,7 @@
     "node_modules/@turf/sector": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
       "dependencies": {
         "@turf/circle": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4055,7 +4091,7 @@
     "node_modules/@turf/shortest-path": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -4071,7 +4107,7 @@
     "node_modules/@turf/simplify": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -4082,7 +4118,7 @@
     "node_modules/@turf/square": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -4091,7 +4127,7 @@
     "node_modules/@turf/square-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
       "dependencies": {
         "@turf/boolean-contains": "^5.1.5",
         "@turf/boolean-overlap": "^5.1.5",
@@ -4104,7 +4140,7 @@
     "node_modules/@turf/standard-deviational-ellipse": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
       "dependencies": {
         "@turf/center-mean": "^5.1.5",
         "@turf/ellipse": "^5.1.5",
@@ -4117,7 +4153,7 @@
     "node_modules/@turf/tag": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -4128,7 +4164,7 @@
     "node_modules/@turf/tesselate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "earcut": "^2.0.0"
@@ -4137,7 +4173,7 @@
     "node_modules/@turf/tin": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -4145,7 +4181,7 @@
     "node_modules/@turf/transform-rotate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
       "dependencies": {
         "@turf/centroid": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -4160,7 +4196,7 @@
     "node_modules/@turf/transform-scale": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -4177,7 +4213,7 @@
     "node_modules/@turf/transform-translate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4189,7 +4225,7 @@
     "node_modules/@turf/triangle-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4200,7 +4236,7 @@
     "node_modules/@turf/truncate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4209,7 +4245,7 @@
     "node_modules/@turf/turf": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
       "dependencies": {
         "@turf/along": "5.1.x",
         "@turf/area": "5.1.x",
@@ -4316,7 +4352,7 @@
     "node_modules/@turf/union": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "turf-jsts": "*"
@@ -4325,7 +4361,7 @@
     "node_modules/@turf/unkink-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -4350,7 +4386,7 @@
     "node_modules/@turf/voronoi": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -4465,9 +4501,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "node_modules/@types/loglevel": {
       "version": "1.6.3",
@@ -4546,9 +4582,9 @@
       }
     },
     "node_modules/@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.8.tgz",
+      "integrity": "sha512-zqqcGKyNWgTLFBxmaexGUKQyWqeG7HjXj20EuQJSJWwXe54BjX0ihIo5cJB9yAQzH8dNugJ9GvkBYMjPXs/PJw=="
     },
     "node_modules/@types/url-search-params": {
       "version": "1.1.0",
@@ -4556,9 +4592,9 @@
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg=="
     },
     "node_modules/@types/validator": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
+      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.25",
@@ -6449,12 +6485,12 @@
       }
     },
     "node_modules/concaveman": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
-      "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
       "dependencies": {
-        "point-in-polygon": "^1.0.1",
-        "rbush": "^3.0.0",
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
         "robust-predicates": "^2.0.4",
         "tinyqueue": "^2.0.3"
       }
@@ -7074,7 +7110,7 @@
     "node_modules/d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
     },
     "node_modules/d3-zoom": {
       "version": "2.0.0",
@@ -7316,7 +7352,7 @@
     "node_modules/density-clustering": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
-      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
+      "integrity": "sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ=="
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -7559,9 +7595,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -8802,7 +8838,7 @@
     "node_modules/filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9072,7 +9108,7 @@
     "node_modules/geojson-equality": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
-      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "integrity": "sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==",
       "dependencies": {
         "deep-equal": "^1.0.0"
       }
@@ -9080,7 +9116,7 @@
     "node_modules/geojson-rbush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
       "dependencies": {
         "@turf/helpers": "*",
         "@turf/meta": "*",
@@ -9103,11 +9139,17 @@
         "ol": "^6.5.0"
       }
     },
+    "node_modules/geostyler-legend/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/geostyler-legend/node_modules/geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "dependencies": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
       },
@@ -9125,12 +9167,12 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.1.0.tgz",
-      "integrity": "sha512-VkFy+oJH0gA1DDwojYIfhbhMH5vHU/RsoWfT7m4nGXXoBH8iHOY/q0EI0mRCeHXDLEsKkxXLLXeZ33h3qWIHxQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
       "dependencies": {
         "@terrestris/ol-util": "^4.0.1",
-        "geostyler-style": "^2.1.0",
+        "geostyler-style": "^4.0.0",
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
@@ -9138,9 +9180,13 @@
       }
     },
     "node_modules/geostyler-style": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.1.0.tgz",
-      "integrity": "sha512-m8bCtckOBZrVZwZ4Vh02kFY2ttLZlSZYMsYPqcNp+/ruIBwADJZvxnsjuY+t63PMsw0s9R05yPVyjVMwtaD/sA=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -9154,7 +9200,7 @@
     "node_modules/get-closest": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
-      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+      "integrity": "sha512-oMgZYUtnPMZB6XieXiUADpRIc5kfD+RPfpiYe9aIlEYGIcOx2mTGgKmUkctlLof/ANleypqOJRhQypbrh33DkA=="
     },
     "node_modules/get-intrinsic": {
       "version": "1.0.1",
@@ -9804,7 +9850,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.2.1",
@@ -12971,7 +13017,7 @@
     "node_modules/jszip": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
       "dependencies": {
         "pako": "~1.0.2"
       }
@@ -13033,7 +13079,7 @@
     "node_modules/lineclip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
-      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
@@ -13101,15 +13147,15 @@
       "dev": true
     },
     "node_modules/loglevel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
       "engines": {
         "node": ">= 0.6.0"
       },
       "funding": {
         "type": "tidelift",
-        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lower-case": {
@@ -14387,9 +14433,9 @@
       }
     },
     "node_modules/point-in-polygon": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
-      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
@@ -14537,12 +14583,12 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.3.tgz",
-      "integrity": "sha512-XRqnLmHWlvi7jqKNTqaOUrVy72JEtOUrnlLki99yZUOSvcSeBaZ1I/EGnQ2LzplSbjSrebGAdikqCLeCxC/YEg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.8.0.tgz",
+      "integrity": "sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.2.4"
+        "wkt-parser": "^1.3.1"
       }
     },
     "node_modules/promise-inflight": {
@@ -14788,9 +14834,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
-      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -15865,7 +15911,7 @@
     "node_modules/shpjs/node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
@@ -16433,7 +16479,7 @@
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
@@ -17467,9 +17513,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -18330,9 +18376,9 @@
       "dev": true
     },
     "node_modules/wkt-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
-      "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
+      "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -21167,39 +21213,39 @@
       }
     },
     "@terrestris/base-util": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-0.2.4.tgz",
-      "integrity": "sha512-HupxqYZvwAaQohBnwJizusNTCPuAaxlYU5HS62xk7axnz6VA6zqnD/oB5ycXpgqNTFSrMBuqlCXuDJx1oS+PZw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-1.0.1.tgz",
+      "integrity": "sha512-ML1IaqZXGWlXrI8pEAnGZv6qPmW72uBZkbc5NvZcBDattpXmrE3rCntTou1t/zLaOz0v4qmG5KORMTSzOeScRQ==",
       "requires": {
-        "@types/lodash": "^4.14.138",
+        "@types/lodash": "^4.14.168",
         "@types/loglevel": "^1.6.3",
         "@types/url-parse": "^1.4.3",
         "@types/url-search-params": "^1.1.0",
-        "@types/validator": "^13.0.0",
-        "lodash": "^4.17.15",
-        "loglevel": "^1.6.3",
-        "query-string": "^6.8.2",
+        "@types/validator": "^13.1.3",
+        "lodash": "^4.17.20",
+        "loglevel": "^1.7.1",
+        "query-string": "^6.13.8",
         "url-parse": "^1.4.7",
         "url-search-params": "^1.1.0",
-        "validator": "^13.0.0"
+        "validator": "^13.5.2"
       }
     },
     "@terrestris/ol-util": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.0.2.tgz",
-      "integrity": "sha512-YI+rdUB+iuH2V50pCQzdsf9Q0Df+efLSh5HpyMRRxGHNTBwTLZWsO+ZZhmQbsYaTuFKeeC1TjQQTsLbJCGOhLg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
       "requires": {
-        "@terrestris/base-util": "^0.2.2",
+        "@terrestris/base-util": "^1.0.0",
         "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.15",
-        "proj4": "^2.6.0",
-        "shpjs": "^3.4.3"
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
       }
     },
     "@turf/along": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -21210,7 +21256,7 @@
     "@turf/area": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21219,7 +21265,7 @@
     "@turf/bbox": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21228,7 +21274,7 @@
     "@turf/bbox-clip": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21238,7 +21284,7 @@
     "@turf/bbox-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -21246,7 +21292,7 @@
     "@turf/bearing": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21255,7 +21301,7 @@
     "@turf/bezier-spline": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21264,7 +21310,7 @@
     "@turf/boolean-clockwise": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21273,7 +21319,7 @@
     "@turf/boolean-contains": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -21285,7 +21331,7 @@
     "@turf/boolean-crosses": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21309,7 +21355,7 @@
     "@turf/boolean-equal": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21320,7 +21366,7 @@
     "@turf/boolean-overlap": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21333,7 +21379,7 @@
     "@turf/boolean-parallel": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21344,7 +21390,7 @@
     "@turf/boolean-point-in-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21353,7 +21399,7 @@
     "@turf/boolean-point-on-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21362,7 +21408,7 @@
     "@turf/boolean-within": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -21374,7 +21420,7 @@
     "@turf/buffer": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -21388,7 +21434,7 @@
     "@turf/center": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -21397,7 +21443,7 @@
     "@turf/center-mean": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21407,7 +21453,7 @@
     "@turf/center-median": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
       "requires": {
         "@turf/center-mean": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -21419,7 +21465,7 @@
     "@turf/center-of-mass": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
       "requires": {
         "@turf/centroid": "^5.1.5",
         "@turf/convex": "^5.1.5",
@@ -21431,7 +21477,7 @@
     "@turf/centroid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21440,7 +21486,7 @@
     "@turf/circle": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
       "requires": {
         "@turf/destination": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -21449,7 +21495,7 @@
     "@turf/clean-coords": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21458,7 +21504,7 @@
     "@turf/clone": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -21466,7 +21512,7 @@
     "@turf/clusters": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21475,7 +21521,7 @@
     "@turf/clusters-dbscan": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -21488,7 +21534,7 @@
     "@turf/clusters-kmeans": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21500,7 +21546,7 @@
     "@turf/collect": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -21526,7 +21572,7 @@
     "@turf/combine": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21535,7 +21581,7 @@
     "@turf/concave": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -21550,7 +21596,7 @@
     "@turf/convex": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5",
@@ -21560,7 +21606,7 @@
     "@turf/destination": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21569,7 +21615,7 @@
     "@turf/difference": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21581,7 +21627,7 @@
     "@turf/dissolve": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
       "requires": {
         "@turf/boolean-overlap": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -21597,7 +21643,7 @@
     "@turf/distance": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21606,7 +21652,7 @@
     "@turf/ellipse": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21617,7 +21663,7 @@
     "@turf/envelope": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -21627,7 +21673,7 @@
     "@turf/explode": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21636,7 +21682,7 @@
     "@turf/flatten": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -21645,7 +21691,7 @@
     "@turf/flip": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21655,7 +21701,7 @@
     "@turf/great-circle": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21664,12 +21710,12 @@
     "@turf/helpers": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
     },
     "@turf/hex-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21680,7 +21726,7 @@
     "@turf/interpolate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -21710,7 +21756,7 @@
     "@turf/invariant": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -21718,7 +21764,7 @@
     "@turf/isobands": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/bbox": "^5.1.5",
@@ -21732,7 +21778,7 @@
     "@turf/isolines": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21743,7 +21789,7 @@
     "@turf/kinks": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -21751,7 +21797,7 @@
     "@turf/length": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21761,7 +21807,7 @@
     "@turf/line-arc": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
       "requires": {
         "@turf/circle": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -21771,7 +21817,7 @@
     "@turf/line-chunk": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/length": "^5.1.5",
@@ -21782,7 +21828,7 @@
     "@turf/line-intersect": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21794,7 +21840,7 @@
     "@turf/line-offset": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21804,7 +21850,7 @@
     "@turf/line-overlap": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
       "requires": {
         "@turf/boolean-point-on-line": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21818,7 +21864,7 @@
     "@turf/line-segment": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21828,7 +21874,7 @@
     "@turf/line-slice": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -21838,7 +21884,7 @@
     "@turf/line-slice-along": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -21849,7 +21895,7 @@
     "@turf/line-split": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21866,7 +21912,7 @@
     "@turf/line-to-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21876,7 +21922,7 @@
     "@turf/mask": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -21903,7 +21949,7 @@
     "@turf/meta": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -21911,7 +21957,7 @@
     "@turf/midpoint": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -21922,7 +21968,7 @@
     "@turf/nearest-point": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -21933,7 +21979,7 @@
     "@turf/nearest-point-on-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -21957,24 +22003,24 @@
       },
       "dependencies": {
         "@turf/helpers": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+          "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
         },
         "@turf/invariant": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-          "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+          "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
           "requires": {
-            "@turf/helpers": "^6.3.0"
+            "@turf/helpers": "^6.5.0"
           }
         },
         "@turf/meta": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-          "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+          "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
           "requires": {
-            "@turf/helpers": "^6.3.0"
+            "@turf/helpers": "^6.5.0"
           }
         }
       }
@@ -21982,7 +22028,7 @@
     "@turf/planepoint": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -21991,7 +22037,7 @@
     "@turf/point-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
       "requires": {
         "@turf/boolean-within": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -22002,7 +22048,7 @@
     "@turf/point-on-feature": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -22027,78 +22073,78 @@
       },
       "dependencies": {
         "@turf/bearing": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",
-          "integrity": "sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+          "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
           "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
+            "@turf/helpers": "^6.5.0",
+            "@turf/invariant": "^6.5.0"
           }
         },
         "@turf/clone": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.3.0.tgz",
-          "integrity": "sha512-GAgN89/9GCqUKECB1oY2hcTs0K2rZj+a2tY6VfM0ef9wwckuQZCKi+kKGUzhKVrmHee15jKV8n6DY0er8OndKg==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
+          "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
           "requires": {
-            "@turf/helpers": "^6.3.0"
+            "@turf/helpers": "^6.5.0"
           }
         },
         "@turf/distance": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
-          "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+          "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
           "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
+            "@turf/helpers": "^6.5.0",
+            "@turf/invariant": "^6.5.0"
           }
         },
         "@turf/helpers": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+          "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
         },
         "@turf/invariant": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-          "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+          "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
           "requires": {
-            "@turf/helpers": "^6.3.0"
+            "@turf/helpers": "^6.5.0"
           }
         },
         "@turf/meta": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-          "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+          "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
           "requires": {
-            "@turf/helpers": "^6.3.0"
+            "@turf/helpers": "^6.5.0"
           }
         },
         "@turf/projection": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.3.0.tgz",
-          "integrity": "sha512-IpSs7Q6G6xi47ynVlYYVegPLy6Jc0yo3/DcIm83jaJa4NnzPFXIFZT0v9Fe1N8MraHZqiqaSPbVnJXCGwR12lg==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
+          "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
           "requires": {
-            "@turf/clone": "^6.3.0",
-            "@turf/helpers": "^6.3.0",
-            "@turf/meta": "^6.3.0"
+            "@turf/clone": "^6.5.0",
+            "@turf/helpers": "^6.5.0",
+            "@turf/meta": "^6.5.0"
           }
         },
         "@turf/rhumb-bearing": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.3.0.tgz",
-          "integrity": "sha512-/c/BE3huEUrwN6gx7Bg2FzfJqeU+TWk/slQPDHpbVunlIPbS6L28brqSVD+KXfMG8HQIzynz6Pm4Y+j5Iv4aWA==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.5.0.tgz",
+          "integrity": "sha512-jMyqiMRK4hzREjQmnLXmkJ+VTNTx1ii8vuqRwJPcTlKbNWfjDz/5JqJlb5NaFDcdMpftWovkW5GevfnuzHnOYA==",
           "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
+            "@turf/helpers": "^6.5.0",
+            "@turf/invariant": "^6.5.0"
           }
         },
         "@turf/rhumb-distance": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.3.0.tgz",
-          "integrity": "sha512-wMIQVvznusonnp/POeucFdA4Rubn0NrkcEMdxdcCgFK7OmTz0zU4CEnNONF2IUGkQ5WwoKiuS7MOTQ8OuCjSfQ==",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.5.0.tgz",
+          "integrity": "sha512-oKp8KFE8E4huC2Z1a1KNcFwjVOqa99isxNOwfo4g3SUABQ6NezjKDDrnvC4yI5YZ3/huDjULLBvhed45xdCrzg==",
           "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
+            "@turf/helpers": "^6.5.0",
+            "@turf/invariant": "^6.5.0"
           }
         }
       }
@@ -22106,7 +22152,7 @@
     "@turf/points-within-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -22116,7 +22162,7 @@
     "@turf/polygon-tangents": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -22125,7 +22171,7 @@
     "@turf/polygon-to-line": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -22134,7 +22180,7 @@
     "@turf/polygonize": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/envelope": "^5.1.5",
@@ -22146,7 +22192,7 @@
     "@turf/projection": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -22156,7 +22202,7 @@
     "@turf/random": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -22164,7 +22210,7 @@
     "@turf/rewind": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
       "requires": {
         "@turf/boolean-clockwise": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -22176,7 +22222,7 @@
     "@turf/rhumb-bearing": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -22185,7 +22231,7 @@
     "@turf/rhumb-destination": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -22194,7 +22240,7 @@
     "@turf/rhumb-distance": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -22203,7 +22249,7 @@
     "@turf/sample": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -22211,7 +22257,7 @@
     "@turf/sector": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
       "requires": {
         "@turf/circle": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -22223,7 +22269,7 @@
     "@turf/shortest-path": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -22239,7 +22285,7 @@
     "@turf/simplify": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -22250,7 +22296,7 @@
     "@turf/square": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -22259,7 +22305,7 @@
     "@turf/square-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
       "requires": {
         "@turf/boolean-contains": "^5.1.5",
         "@turf/boolean-overlap": "^5.1.5",
@@ -22272,7 +22318,7 @@
     "@turf/standard-deviational-ellipse": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
       "requires": {
         "@turf/center-mean": "^5.1.5",
         "@turf/ellipse": "^5.1.5",
@@ -22285,7 +22331,7 @@
     "@turf/tag": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -22296,7 +22342,7 @@
     "@turf/tesselate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "earcut": "^2.0.0"
@@ -22305,7 +22351,7 @@
     "@turf/tin": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -22313,7 +22359,7 @@
     "@turf/transform-rotate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
       "requires": {
         "@turf/centroid": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -22328,7 +22374,7 @@
     "@turf/transform-scale": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -22345,7 +22391,7 @@
     "@turf/transform-translate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -22357,7 +22403,7 @@
     "@turf/triangle-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -22368,7 +22414,7 @@
     "@turf/truncate": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -22377,7 +22423,7 @@
     "@turf/turf": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
       "requires": {
         "@turf/along": "5.1.x",
         "@turf/area": "5.1.x",
@@ -22484,7 +22530,7 @@
     "@turf/union": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "turf-jsts": "*"
@@ -22493,7 +22539,7 @@
     "@turf/unkink-polygon": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -22520,7 +22566,7 @@
     "@turf/voronoi": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -22635,9 +22681,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "@types/loglevel": {
       "version": "1.6.3",
@@ -22714,9 +22760,9 @@
       }
     },
     "@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.8.tgz",
+      "integrity": "sha512-zqqcGKyNWgTLFBxmaexGUKQyWqeG7HjXj20EuQJSJWwXe54BjX0ihIo5cJB9yAQzH8dNugJ9GvkBYMjPXs/PJw=="
     },
     "@types/url-search-params": {
       "version": "1.1.0",
@@ -22724,9 +22770,9 @@
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg=="
     },
     "@types/validator": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
+      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA=="
     },
     "@types/webpack": {
       "version": "4.41.25",
@@ -24315,12 +24361,12 @@
       }
     },
     "concaveman": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
-      "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
       "requires": {
-        "point-in-polygon": "^1.0.1",
-        "rbush": "^3.0.0",
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
         "robust-predicates": "^2.0.4",
         "tinyqueue": "^2.0.3"
       }
@@ -24914,7 +24960,7 @@
     "d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
     },
     "d3-zoom": {
       "version": "2.0.0",
@@ -25089,7 +25135,7 @@
     "density-clustering": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
-      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
+      "integrity": "sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -25309,9 +25355,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -26290,7 +26336,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -26505,7 +26551,7 @@
     "geojson-equality": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
-      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "integrity": "sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==",
       "requires": {
         "deep-equal": "^1.0.0"
       }
@@ -26513,7 +26559,7 @@
     "geojson-rbush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
       "requires": {
         "@turf/helpers": "*",
         "@turf/meta": "*",
@@ -26529,11 +26575,17 @@
         "geostyler-openlayers-parser": "^3.0.0"
       },
       "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "geostyler-openlayers-parser": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-          "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+          "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
           "requires": {
+            "color-name": "^1.1.4",
             "geostyler-style": "^5.0.2",
             "lodash": "^4.17.21"
           }
@@ -26550,19 +26602,23 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.1.0.tgz",
-      "integrity": "sha512-VkFy+oJH0gA1DDwojYIfhbhMH5vHU/RsoWfT7m4nGXXoBH8iHOY/q0EI0mRCeHXDLEsKkxXLLXeZ33h3qWIHxQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
       "requires": {
         "@terrestris/ol-util": "^4.0.1",
-        "geostyler-style": "^2.1.0",
+        "geostyler-style": "^4.0.0",
         "lodash": "^4.17.15"
       }
     },
     "geostyler-style": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.1.0.tgz",
-      "integrity": "sha512-m8bCtckOBZrVZwZ4Vh02kFY2ttLZlSZYMsYPqcNp+/ruIBwADJZvxnsjuY+t63PMsw0s9R05yPVyjVMwtaD/sA=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "requires": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -26573,7 +26629,7 @@
     "get-closest": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
-      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+      "integrity": "sha512-oMgZYUtnPMZB6XieXiUADpRIc5kfD+RPfpiYe9aIlEYGIcOx2mTGgKmUkctlLof/ANleypqOJRhQypbrh33DkA=="
     },
     "get-intrinsic": {
       "version": "1.0.1",
@@ -27092,7 +27148,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -29481,7 +29537,7 @@
     "jszip": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
       "requires": {
         "pako": "~1.0.2"
       }
@@ -29531,7 +29587,7 @@
     "lineclip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
-      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A=="
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -29589,9 +29645,9 @@
       "dev": true
     },
     "loglevel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "lower-case": {
       "version": "2.0.2",
@@ -30641,9 +30697,9 @@
       "dev": true
     },
     "point-in-polygon": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
-      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -30758,12 +30814,12 @@
       "dev": true
     },
     "proj4": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.3.tgz",
-      "integrity": "sha512-XRqnLmHWlvi7jqKNTqaOUrVy72JEtOUrnlLki99yZUOSvcSeBaZ1I/EGnQ2LzplSbjSrebGAdikqCLeCxC/YEg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.8.0.tgz",
+      "integrity": "sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==",
       "requires": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.2.4"
+        "wkt-parser": "^1.3.1"
       }
     },
     "promise-inflight": {
@@ -30964,9 +31020,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
-      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -31859,7 +31915,7 @@
         "lru-cache": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
         }
       }
     },
@@ -32349,7 +32405,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -33180,9 +33236,9 @@
       }
     },
     "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -33888,9 +33944,9 @@
       "dev": true
     },
     "wkt-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
-      "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
+      "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "geostyler-legend": "^2.2.0",
-    "geostyler-openlayers-parser": "^2.1.0",
+    "geostyler-openlayers-parser": "^2.5.0",
     "ol": "^6.5.0",
     "proj4": "^2.6.3",
     "rxjs": "^6.6.3"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/camptocamp/inkmap#readme",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "geostyler-legend": "^2.2.0",
     "geostyler-openlayers-parser": "^2.1.0",
     "ol": "^6.5.0",
     "proj4": "^2.6.3",
@@ -50,6 +51,7 @@
     "eslint": "^7.12.1",
     "eslint-config-prettier": "^6.15.0",
     "html-webpack-plugin": "^4.5.0",
+    "isomorphic-fetch": "^3.0.0",
     "jest": "^26.6.1",
     "jest-canvas-mock": "^2.3.1",
     "jspdf": "^2.2.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -187,11 +187,12 @@ export function queuePrint(printSpec) {
  * @return {Promise<Blob>} Promise resolving to the final legend image blob.
  */
 export function createLegends(printSpec) {
-  const spec = printSpec.value ? printSpec.value : printSpec;
-  if (spec.layers.find(el => el.legend)) {
-    return getLegends(spec);
+  if (printSpec.layers.find((el) => el.legend)) {
+    return getLegends(printSpec);
   } else {
-    console.warn('The given spec did not include any layer with a configured legend');
+    console.warn(
+      'The given spec did not include any layer with a configured legend'
+    );
   }
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -9,6 +9,7 @@ import {
   getJobStatusObservable,
   newJob$,
 } from './jobs';
+import getLegends from '../shared/widgets/legends';
 
 export { downloadBlob } from './utils';
 
@@ -32,6 +33,7 @@ export { downloadBlob } from './utils';
  * @property {number} opacity Opacity, from 0 (hidden) to 1 (visible).
  * @property {boolean} [tiled=false] Whether the WMS layer should be requested as tiles.
  * @property {string} [attribution] Attribution for the data used in the layer
+ * @property {boolean} [legend=false] Whether a legend should be created for this layer.
  */
 
 /**
@@ -41,6 +43,7 @@ export { downloadBlob } from './utils';
  *   Note: tile grids are expected to have their x=0,y=0 point at the top left corner; for tile grids where it is at the bottom left corner, use the `{-y}` placeholder.
  * @property {number} opacity Opacity, from 0 (hidden) to 1 (visible).
  * @property {string} [attribution] Attribution for the data used in the layer
+ * @property {boolean} [legend=false] Whether a legend should be created for this layer.
  */
 
 /**
@@ -49,6 +52,7 @@ export { downloadBlob } from './utils';
  * @property {Object} geojson Feature collection in GeoJSON format; coordinates are expected to be in the print job reference system
  * @property {Object} style JSON object in geostyler notation, defining the layer style.
  * @property {string} [attribution] Attribution for the data used in the layer
+ * @property {boolean} [legend=false] Whether a legend should be created for this layer.
  */
 
 /**
@@ -64,6 +68,7 @@ export { downloadBlob } from './utils';
  * @property {string} matrixSet Matrix set.
  * @property {TileGrid} tileGrid Tile grid.
  * @property {string} [attribution] Attribution for the data used in the layer
+ * @property {boolean} [legend=false] Whether a legend should be created for this layer.
  */
 
 /**
@@ -75,6 +80,7 @@ export { downloadBlob } from './utils';
  * @property {string} format Format used when querying WFS, `gml` (default) or `geojson`. inkmap determines the GML parser based on the WFS version used.
  * @property {Object} style JSON object in geostyler notation, defining the layer style.
  * @property {string} [attribution] Attribution for the data used in the layer
+ * @property {boolean} [legend=false] Whether a legend should be created for this layer.
  */
 
 /**
@@ -173,6 +179,20 @@ export function queuePrint(printSpec) {
       map((job) => job.id)
     )
     .toPromise();
+}
+
+/**
+ * Starts generating a legend image from a print spec.
+ * @param {PrintSpec} printSpec
+ * @return {Promise<Blob>} Promise resolving to the final legend image blob.
+ */
+export function createLegends(printSpec) {
+  const spec = printSpec.value ? printSpec.value : printSpec;
+  if (spec.layers.find(el => el.legend)) {
+    return getLegends(spec);
+  } else {
+    console.warn('The given spec did not include any layer with a configured legend');
+  }
 }
 
 /**

--- a/src/shared/widgets/legends.js
+++ b/src/shared/widgets/legends.js
@@ -6,10 +6,13 @@ import LegendRenderer from 'geostyler-legend/dist/LegendRenderer/LegendRenderer'
  * @param {import("../../main/index.js").PrintSpec} spec
  */
 export default async function getLegends(spec) {
-  const wmsLayers = spec.layers.filter(layer => layer.type === 'WMS');
-  const vectorLayers = spec.layers.filter(layer => layer.type === 'WFS' ||
-    layer.type === 'GeoJSON');
-  const vectorLayerStyles = vectorLayers.map(layer => layer.style);
+  const wmsLayers = /** @type {Array<import("../../main/index.js").WmsLayer>} */ (spec.layers.filter(
+    (layer) => layer.type === 'WMS'
+  ));
+  const vectorLayers = /** @type {Array<import("../../main/index.js").WfsLayer|import("../../main/index.js").GeoJSONLayer>} */ (spec.layers.filter(
+    (layer) => layer.type === 'WFS' || layer.type === 'GeoJSON'
+  ));
+  const vectorLayerStyles = vectorLayers.map((layer) => layer.style);
   const remoteLegends = [];
 
   wmsLayers.forEach(layer => {
@@ -19,10 +22,13 @@ export default async function getLegends(spec) {
     url.searchParams.set('VERSION', layer.version || '1.3.0');
     url.searchParams.set('LAYER', layer.layer);
     url.searchParams.set('FORMAT', 'image/png');
-    url.searchParams.set('DPI', spec.dpi || (layer.version === '1.1.1' ? 72 : 91));
-  
+    url.searchParams.set(
+      'DPI',
+      (spec.dpi || (layer.version === '1.1.1' ? 72 : 91)).toString()
+    );
+
     if (spec.scale) {
-      url.searchParams.set('SCALE', spec.scale);
+      url.searchParams.set('SCALE', spec.scale.toString());
     }
 
     remoteLegends.push({

--- a/src/shared/widgets/legends.js
+++ b/src/shared/widgets/legends.js
@@ -15,7 +15,7 @@ export default async function getLegends(spec) {
   const vectorLayerStyles = vectorLayers.map((layer) => layer.style);
   const remoteLegends = [];
 
-  wmsLayers.forEach(layer => {
+  wmsLayers.forEach((layer) => {
     const url = new URL(layer.url);
     url.searchParams.set('REQUEST', 'GetLegendGraphic');
     url.searchParams.set('SERVICE', 'WMS');
@@ -33,7 +33,7 @@ export default async function getLegends(spec) {
 
     remoteLegends.push({
       url: url.toString(),
-      title: layer.layer
+      title: layer.layer,
     });
   });
 
@@ -43,12 +43,12 @@ export default async function getLegends(spec) {
     overflow: 'auto',
     styles: vectorLayerStyles,
     remoteLegends: remoteLegends,
-    size: [595, 842]
+    size: [595, 842],
   });
 
-  const div = document.createElement("div");
+  const div = document.createElement('div');
   const svgParent = await renderer.render(div);
   let svgString = svgParent.node().outerHTML;
-  const blob = new Blob([svgString], {type: 'image/svg+xml'});
+  const blob = new Blob([svgString], { type: 'image/svg+xml' });
   return blob;
 }

--- a/src/shared/widgets/legends.js
+++ b/src/shared/widgets/legends.js
@@ -1,0 +1,48 @@
+import LegendRenderer from 'geostyler-legend/dist/LegendRenderer/LegendRenderer';
+
+/**
+ * Create and download a separate image containing legends for all layers
+ * that have a legend configured by the given spec.
+ * @param {import("../../main/index.js").PrintSpec} spec
+ */
+export default async function getLegends(spec) {
+  const wmsLayers = spec.layers.filter(layer => layer.type === 'WMS');
+  const vectorLayers = spec.layers.filter(layer => layer.type === 'WFS' ||
+    layer.type === 'GeoJSON');
+  const vectorLayerStyles = vectorLayers.map(layer => layer.style);
+  const remoteLegends = [];
+
+  wmsLayers.forEach(layer => {
+    const url = new URL(layer.url);
+    url.searchParams.set('REQUEST', 'GetLegendGraphic');
+    url.searchParams.set('SERVICE', 'WMS');
+    url.searchParams.set('VERSION', layer.version || '1.3.0');
+    url.searchParams.set('LAYER', layer.layer);
+    url.searchParams.set('FORMAT', 'image/png');
+    url.searchParams.set('DPI', spec.dpi || (layer.version === '1.1.1' ? 72 : 91));
+  
+    if (spec.scale) {
+      url.searchParams.set('SCALE', spec.scale);
+    }
+
+    remoteLegends.push({
+      url: url.toString(),
+      title: layer.layer
+    });
+  });
+
+  const renderer = new LegendRenderer({
+    maxColumnWidth: 290,
+    maxColumnHeight: 840,
+    overflow: 'auto',
+    styles: vectorLayerStyles,
+    remoteLegends: remoteLegends,
+    size: [595, 842]
+  });
+
+  const div = document.createElement("div");
+  const svgParent = await renderer.render(div);
+  let svgString = svgParent.node().outerHTML;
+  const blob = new Blob([svgString], {type: 'image/svg+xml'});
+  return blob;
+}

--- a/test/unit/legends.test.js
+++ b/test/unit/legends.test.js
@@ -5,22 +5,26 @@ import 'isomorphic-fetch';
 describe('legends', () => {
   describe('getLegends', () => {
     const spec = PresetSpecs['Spec with legends'];
-    const expectedUrl = 'https://ows.terrestris.de/osm/service?' +
-        'REQUEST=GetLegendGraphic&SERVICE=WMS&VERSION=1.3.0&LAYER' + 
-        '=OSM-WMS&FORMAT=image%2Fpng&DPI=72&SCALE=7000000';
+    const expectedUrl =
+      'https://ows.terrestris.de/osm/service?' +
+      'REQUEST=GetLegendGraphic&SERVICE=WMS&VERSION=1.3.0&LAYER' +
+      '=OSM-WMS&FORMAT=image%2Fpng&DPI=72&SCALE=7000000';
     let fetchedUrl;
 
-    it('creates a getLegendGraphic URL for given spec', async() => {
+    it('creates a getLegendGraphic URL for given spec', async () => {
       global.fetch = jest.fn((url) => {
         fetchedUrl = url;
         return Promise.resolve({
-          blob: () => Promise.resolve(new Blob(
-            ['<image src="data:image/png;base64,"></image>'],
-            {type: 'image/png'}))
-        })}
-      );
-      HTMLImageElement.prototype.decode = () => new Promise(
-        (resolve) => resolve());
+          blob: () =>
+            Promise.resolve(
+              new Blob(['<image src="data:image/png;base64,"></image>'], {
+                type: 'image/png',
+              })
+            ),
+        });
+      });
+      HTMLImageElement.prototype.decode = () =>
+        new Promise((resolve) => resolve());
 
       const imageBlob = await getLegends(spec);
       expect(fetchedUrl).toBe(expectedUrl);

--- a/test/unit/legends.test.js
+++ b/test/unit/legends.test.js
@@ -1,0 +1,31 @@
+import getLegends from '../../src/shared/widgets/legends';
+import PresetSpecs from '../../demo/preset-specs';
+import 'isomorphic-fetch';
+
+describe('legends', () => {
+  describe('getLegends', () => {
+    const spec = PresetSpecs['Spec with legends'];
+    const expectedUrl = 'https://ows.terrestris.de/osm/service?' +
+        'REQUEST=GetLegendGraphic&SERVICE=WMS&VERSION=1.3.0&LAYER' + 
+        '=OSM-WMS&FORMAT=image%2Fpng&DPI=72&SCALE=7000000';
+    let fetchedUrl;
+
+    it('creates a getLegendGraphic URL for given spec', async() => {
+      global.fetch = jest.fn((url) => {
+        fetchedUrl = url;
+        return Promise.resolve({
+          blob: () => Promise.resolve(new Blob(
+            ['<image src="data:image/png;base64,"></image>'],
+            {type: 'image/png'}))
+        })}
+      );
+      HTMLImageElement.prototype.decode = () => new Promise(
+        (resolve) => resolve());
+
+      const imageBlob = await getLegends(spec);
+      expect(fetchedUrl).toBe(expectedUrl);
+      expect(imageBlob).toBeDefined();
+      expect(imageBlob).toBeInstanceOf(Blob);
+    });
+  });
+});


### PR DESCRIPTION
This enables printing of legends through the `geostyler-legend` module.
Currently, GeoJSON, WFS and WMS Layers are supported.

A new boolean `legend` has been introduced on the layer level of the spec to indicate that a legend should be generated when calling the new `createLegend` method.

In the future it may be better to have a separate legend configuration object with more control.

Examples and tests have been added.

@jahow please review