### PR TITLE
Updating openlayers to latest 6.x release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime": "^7.12.5",
         "geostyler-legend": "^2.2.0",
         "geostyler-openlayers-parser": "^2.5.0",
-        "ol": "^6.5.0",
+        "ol": "^6.15.1",
         "proj4": "^2.6.3",
         "rxjs": "^6.6.3"
       },
@@ -40,7 +40,7 @@
         "yargs": "^16.1.0"
       },
       "engines": {
-        "node": "16"
+        "node": ">=16 <18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2949,41 +2949,46 @@
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.18.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.18.1.tgz",
-      "integrity": "sha512-By+CufXEpba7sIUfnpbtVzy5tqrCyFDNssq1k7psxzCL1Xr0y916OSkEH0j7fFilhalVExjoh/mYtxH32tOYqw==",
+      "version": "13.27.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.27.0.tgz",
+      "integrity": "sha512-wQSJCGRyf7pWknQgeGBArHEk8898UcI1BnAam7IRa3AGmHRFzlJ6DzoU24Hld9zJ0tgkNQ7OP5sJT/9hKHzavg==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
         "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       },
       "bin": {
-        "gl-style-composite": "bin/gl-style-composite",
-        "gl-style-format": "bin/gl-style-format",
-        "gl-style-migrate": "bin/gl-style-migrate",
-        "gl-style-validate": "bin/gl-style-validate"
+        "gl-style-composite": "bin/gl-style-composite.js",
+        "gl-style-format": "bin/gl-style-format.js",
+        "gl-style-migrate": "bin/gl-style-migrate.js",
+        "gl-style-validate": "bin/gl-style-validate.js"
       }
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
+      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.1",
@@ -3019,24 +3024,6 @@
         "url-parse": "^1.4.7",
         "url-search-params": "^1.1.0",
         "validator": "^13.5.2"
-      }
-    },
-    "node_modules/@terrestris/ol-util": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "dependencies": {
-        "@terrestris/base-util": "^1.0.0",
-        "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.20",
-        "proj4": "^2.7.0",
-        "shpjs": "^3.6.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "ol": "~6.5"
       }
     },
     "node_modules/@turf/along": {
@@ -4595,9 +4582,9 @@
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg=="
     },
     "node_modules/@types/validator": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
-      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA=="
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.25",
@@ -6765,7 +6752,7 @@
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/cssfontparser": {
       "version": "1.2.1",
@@ -7608,9 +7595,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -9199,6 +9186,24 @@
         "ol": "^6.0.0"
       }
     },
+    "node_modules/geostyler-openlayers-parser/node_modules/@terrestris/ol-util": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+      "dependencies": {
+        "@terrestris/base-util": "^1.0.0",
+        "@turf/turf": "^5.1.6",
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "ol": "~6.5"
+      }
+    },
     "node_modules/geostyler-style": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
@@ -9207,6 +9212,45 @@
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/geotiff": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
+      "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2"
+      },
+      "engines": {
+        "browsers": "defaults",
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
+    "node_modules/geotiff/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -13035,9 +13079,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.7.0.tgz",
+      "integrity": "sha512-JIsRKRVC3gTRo2vM4Wy9WBC3TRcfnIZU8k65Phi3izkvPH975FowRYtKGT6PxevA0XnJ/yO8b0QwV0ydVyQwfw==",
       "dependencies": {
         "pako": "~1.0.2"
       }
@@ -13065,6 +13109,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -13246,9 +13295,9 @@
       }
     },
     "node_modules/mapbox-to-css-font": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
-      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
+      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -13416,9 +13465,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mississippi": {
       "version": "3.0.0",
@@ -13952,11 +14004,12 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
+      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
       "dependencies": {
-        "ol-mapbox-style": "^6.1.1",
+        "geotiff": "2.0.4",
+        "ol-mapbox-style": "^8.0.5",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -13966,16 +14019,12 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.3.0.tgz",
-      "integrity": "sha512-oRMP5nTEHvF8OoH0sofXElJGi1RV84H27M67nbb2AKcElGag/Z9a6FoI15+J/LSxsg5E1IOW4pIHi0w5ZOUIVg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
+      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
-        "mapbox-to-css-font": "^2.4.0",
-        "webfont-matcher": "^1.1.0"
-      },
-      "peerDependencies": {
-        "ol": "^6.1.0"
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "mapbox-to-css-font": "^2.4.1"
       }
     },
     "node_modules/on-finished": {
@@ -14198,6 +14247,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "5.1.0",
@@ -16176,7 +16230,7 @@
     "node_modules/sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
+      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16184,7 +16238,7 @@
     "node_modules/sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
+      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16192,7 +16246,7 @@
     "node_modules/sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
       "dependencies": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -17768,10 +17822,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/webfont-matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -18603,6 +18657,11 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "node_modules/xml-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
+      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA=="
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -21194,19 +21253,19 @@
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.18.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.18.1.tgz",
-      "integrity": "sha512-By+CufXEpba7sIUfnpbtVzy5tqrCyFDNssq1k7psxzCL1Xr0y916OSkEH0j7fFilhalVExjoh/mYtxH32tOYqw==",
+      "version": "13.27.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.27.0.tgz",
+      "integrity": "sha512-wQSJCGRyf7pWknQgeGBArHEk8898UcI1BnAam7IRa3AGmHRFzlJ6DzoU24Hld9zJ0tgkNQ7OP5sJT/9hKHzavg==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
         "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       }
@@ -21214,12 +21273,17 @@
     "@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+    },
+    "@petamoriken/float16": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
+      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg=="
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
@@ -21255,18 +21319,6 @@
         "url-parse": "^1.4.7",
         "url-search-params": "^1.1.0",
         "validator": "^13.5.2"
-      }
-    },
-    "@terrestris/ol-util": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "requires": {
-        "@terrestris/base-util": "^1.0.0",
-        "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.20",
-        "proj4": "^2.7.0",
-        "shpjs": "^3.6.3"
       }
     },
     "@turf/along": {
@@ -22797,9 +22849,9 @@
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg=="
     },
     "@types/validator": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
-      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA=="
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ=="
     },
     "@types/webpack": {
       "version": "4.41.25",
@@ -24628,7 +24680,7 @@
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "cssfontparser": {
       "version": "1.2.1",
@@ -25392,9 +25444,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -26653,6 +26705,20 @@
         "@terrestris/ol-util": "^4.0.1",
         "geostyler-style": "^4.0.0",
         "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@terrestris/ol-util": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+          "requires": {
+            "@terrestris/base-util": "^1.0.0",
+            "@turf/turf": "^5.1.6",
+            "lodash": "^4.17.20",
+            "proj4": "^2.7.0",
+            "shpjs": "^3.6.3"
+          }
+        }
       }
     },
     "geostyler-style": {
@@ -26662,6 +26728,40 @@
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
+      }
+    },
+    "geotiff": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
+      "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
+      "requires": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "get-caller-file": {
@@ -29579,9 +29679,9 @@
       }
     },
     "jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.7.0.tgz",
+      "integrity": "sha512-JIsRKRVC3gTRo2vM4Wy9WBC3TRcfnIZU8k65Phi3izkvPH975FowRYtKGT6PxevA0XnJ/yO8b0QwV0ydVyQwfw==",
       "requires": {
         "pako": "~1.0.2"
       }
@@ -29603,6 +29703,11 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "leven": {
       "version": "3.1.0",
@@ -29754,9 +29859,9 @@
       }
     },
     "mapbox-to-css-font": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
-      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
+      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -29896,9 +30001,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -30345,23 +30450,23 @@
       "dev": true
     },
     "ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
+      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
       "requires": {
-        "ol-mapbox-style": "^6.1.1",
+        "geotiff": "2.0.4",
+        "ol-mapbox-style": "^8.0.5",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       }
     },
     "ol-mapbox-style": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.3.0.tgz",
-      "integrity": "sha512-oRMP5nTEHvF8OoH0sofXElJGi1RV84H27M67nbb2AKcElGag/Z9a6FoI15+J/LSxsg5E1IOW4pIHi0w5ZOUIVg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
+      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
       "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
-        "mapbox-to-css-font": "^2.4.0",
-        "webfont-matcher": "^1.1.0"
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "mapbox-to-css-font": "^2.4.1"
       }
     },
     "on-finished": {
@@ -30541,6 +30646,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-headers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parse-json": {
       "version": "5.1.0",
@@ -32174,17 +32284,17 @@
     "sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
+      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw=="
     },
     "sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
+      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw=="
     },
     "sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
       "requires": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -33481,10 +33591,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "webfont-matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+    "web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -34153,6 +34263,11 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
+      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src/"
   ],
   "engines": {
-    "node": "16"
+    "node": ">=16 <18"
   },
   "scripts": {
     "lint": "eslint src",
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.12.5",
     "geostyler-legend": "^2.2.0",
     "geostyler-openlayers-parser": "^2.5.0",
-    "ol": "^6.5.0",
+    "ol": "^6.15.1",
     "proj4": "^2.6.3",
     "rxjs": "^6.6.3"
   },

--- a/src/printer/utils.js
+++ b/src/printer/utils.js
@@ -1,6 +1,5 @@
 import { isWorker } from '../worker/utils';
 import { from, Observable } from 'rxjs';
-import sourceState from 'ol/source/State';
 import { fromLonLat, get as getProjection } from 'ol/proj';
 import {
   registerWithExtent,
@@ -12,6 +11,13 @@ import TileQueue, {
 } from 'ol/TileQueue';
 import { CM_PER_INCH } from '../shared/constants';
 import { scaleToResolution } from '../shared/units';
+
+const sourceState = {
+  UNDEFINED: 'undefined',
+  LOADING: 'loading',
+  READY: 'ready',
+  ERROR: 'error'
+};
 
 /**
  * Transforms a canvas to a Blob through an observable


### PR DESCRIPTION
Since OpenLayers v6.15.0, some enum classes have been removed (e.g. ol/source/State):
https://github.com/openlayers/openlayers/blob/v6.15.0/changelog/v6.15.0.md#replacement-of-string-enums-with-union-types

Using newer OpenLayers versions will fail because of usage of those classes. I only had issues with ol/source/State though, the others seem to be unused in inkmap.

I also tried to update openlayers to v7, but it seems there is some more work involved to do so.

@jahow please review
