### PR TITLE
Job context for matching job id to queue request

### DIFF
--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -44,6 +44,17 @@ export const printerReady = new Promise((resolve) => {
   }
 });
 
+/** Pseudorandom UUIDv4 generator. Source: https://stackoverflow.com/a/2117523 */
+export function uuidv4() {
+  return `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(/[018]/g, (c) => {
+    const int = parseInt(c);
+    return (
+      int ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (int / 4)))
+    ).toString(16);
+  });
+}
+
 printerReady.then((useWorker) =>
   console.log(
     `[inkmap] Ready, ${useWorker ? 'using worker' : 'using main thread'}`

--- a/src/printer/dispatcher.js
+++ b/src/printer/dispatcher.js
@@ -5,7 +5,7 @@ import { MESSAGE_JOB_CANCEL, MESSAGE_JOB_REQUEST } from '../shared/constants';
 messageToPrinter$.subscribe((message) => {
   switch (message.type) {
     case MESSAGE_JOB_REQUEST:
-      createJob(message.spec);
+      createJob(message.spec, message.jobContext);
       break;
     case MESSAGE_JOB_CANCEL:
       cancelJob(message.jobId);

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -18,8 +18,9 @@ let counter = 0;
  * Note: this will broadcast the job status updates to the main thread
  * until the job is over.
  * @param {import('../main/index').PrintSpec} spec
+ * @param {string} jobContext
  */
-export async function createJob(spec) {
+export async function createJob(spec, jobContext) {
   registerProjections(spec.projectionDefinitions);
   const sizeInPixel = calculateSizeInPixel(spec);
   const frameState = await getJobFrameState(spec, sizeInPixel);
@@ -33,6 +34,7 @@ export async function createJob(spec) {
     status: 'pending',
     progress: 0,
     sourceLoadErrors: [],
+    jobContext,
   };
 
   const context = createCanvasContext2D(sizeInPixel[0], sizeInPixel[1]);


### PR DESCRIPTION
Fixes #56 

Calls to queuePrint were incorrectly reporting the same id to all calls. Now the jobContext associates a job to a request.

The jobContext could replace the jobId entirely, but that would break backwards compatibility since jobId type would change from number to string.