### PR TITLE
Handle multiple jobs created simultaneously

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/runtime": "^7.12.5",
         "geostyler-legend": "^2.2.0",
         "geostyler-openlayers-parser": "^2.5.0",
+        "lodash": "^4.17.21",
         "ol": "^6.5.0",
         "proj4": "^2.6.3",
         "rxjs": "^6.6.3"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/runtime": "^7.12.5",
     "geostyler-legend": "^2.2.0",
     "geostyler-openlayers-parser": "^2.5.0",
+    "lodash": "^4.17.21",
     "ol": "^6.5.0",
     "proj4": "^2.6.3",
     "rxjs": "^6.6.3"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,13 +1,13 @@
-import { map, switchMap, take, takeWhile } from 'rxjs/operators';
+import { map, switchMap, takeWhile } from 'rxjs/operators';
 
 import '../printer';
 import { MESSAGE_JOB_CANCEL, MESSAGE_JOB_REQUEST } from '../shared/constants';
 import { registerWithExtent } from '../shared/projections';
 import { messageToPrinter } from './exchange';
 import {
+  createNewJob,
   getJobsStatusObservable,
   getJobStatusObservable,
-  newJob$,
 } from './jobs';
 import getLegends from '../shared/widgets/legends';
 
@@ -156,10 +156,9 @@ export { downloadBlob } from './utils';
  */
 export function print(printSpec) {
   messageToPrinter(MESSAGE_JOB_REQUEST, { spec: printSpec });
-  return newJob$
+  return createNewJob(printSpec)
     .pipe(
-      take(1),
-      switchMap((job) => getJobStatusObservable(job.id)),
+      switchMap((jobId) => getJobStatusObservable(jobId)),
       takeWhile((job) => job.progress < 1, true),
       map((job) => job.imageBlob)
     )
@@ -173,13 +172,7 @@ export function print(printSpec) {
  * @return {Promise<number>} Promise resolving to the print job id.
  */
 export function queuePrint(printSpec) {
-  messageToPrinter(MESSAGE_JOB_REQUEST, { spec: printSpec });
-  return newJob$
-    .pipe(
-      take(1),
-      map((job) => job.id)
-    )
-    .toPromise();
+  return createNewJob(printSpec).toPromise();
 }
 
 /**

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -6,10 +6,11 @@ import {
   shareReplay,
   startWith,
   switchMap,
+  take,
 } from 'rxjs/operators';
 import { from } from 'rxjs';
-import { messageToMain$ } from './exchange';
-import { MESSAGE_JOB_STATUS } from '../shared/constants';
+import { messageToMain$, messageToPrinter } from './exchange';
+import { MESSAGE_JOB_REQUEST, MESSAGE_JOB_STATUS } from '../shared/constants';
 
 export const jobs$ = messageToMain$.pipe(
   filter((message) => message.type === MESSAGE_JOB_STATUS),
@@ -49,5 +50,17 @@ export function getJobStatusObservable(jobId) {
   return jobs$.pipe(
     map((jobs) => jobs.find((job) => job.id === jobId)),
     filter((job) => !!job)
+  );
+}
+
+/**
+ * @param {import('.').PrintSpec} printSpec
+ * @return {import('rxjs').Observable<number>} Observable emitting the print job id and completing afterwards
+ */
+export function createNewJob(printSpec) {
+  messageToPrinter(MESSAGE_JOB_REQUEST, { spec: printSpec });
+  return newJob$.pipe(
+    take(1),
+    map((job) => job.id)
   );
 }

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -58,8 +58,10 @@ export function getJobStatusObservable(jobId) {
  * @return {import('rxjs').Observable<number>} Observable emitting the print job id and completing afterwards
  */
 export function createNewJob(printSpec) {
+  const specJson = JSON.stringify(printSpec);
   messageToPrinter(MESSAGE_JOB_REQUEST, { spec: printSpec });
   return newJob$.pipe(
+    filter((job) => JSON.stringify(job.spec) === specJson),
     take(1),
     map((job) => job.id)
   );

--- a/src/main/jobs.js
+++ b/src/main/jobs.js
@@ -11,6 +11,7 @@ import {
 import { from } from 'rxjs';
 import { messageToMain$, messageToPrinter } from './exchange';
 import { MESSAGE_JOB_REQUEST, MESSAGE_JOB_STATUS } from '../shared/constants';
+import isEqual from 'lodash/isEqual';
 
 export const jobs$ = messageToMain$.pipe(
   filter((message) => message.type === MESSAGE_JOB_STATUS),
@@ -58,10 +59,9 @@ export function getJobStatusObservable(jobId) {
  * @return {import('rxjs').Observable<number>} Observable emitting the print job id and completing afterwards
  */
 export function createNewJob(printSpec) {
-  const specJson = JSON.stringify(printSpec);
   messageToPrinter(MESSAGE_JOB_REQUEST, { spec: printSpec });
   return newJob$.pipe(
-    filter((job) => JSON.stringify(job.spec) === specJson),
+    filter((job) => isEqual(job.spec, printSpec)),
     take(1),
     map((job) => job.id)
   );

--- a/src/printer/job.js
+++ b/src/printer/job.js
@@ -37,11 +37,14 @@ export async function createJob(spec) {
 
   const context = createCanvasContext2D(sizeInPixel[0], sizeInPixel[1]);
 
-  combineLatest(
-    spec.layers.map((layer) => {
-      return createLayer(job.id, layer, frameState);
-    })
-  )
+  const layerStates$ = spec.layers.length
+    ? combineLatest(
+        spec.layers.map((layer) => {
+          return createLayer(job.id, layer, frameState);
+        })
+      )
+    : of([]);
+  layerStates$
     .pipe(
       switchMap((layerStates) => {
         const allReady = layerStates.every(([progress]) => progress === 1);

--- a/test/unit/jobs.test.js
+++ b/test/unit/jobs.test.js
@@ -1,0 +1,42 @@
+import '../../src/main'; // this will also initialize all message exchange logic
+import { createNewJob } from '../../src/main/jobs';
+import { combineLatest, of } from 'rxjs';
+
+jest.mock('../../src/printer/utils', () => ({
+  ...jest.requireActual('../../src/printer/utils'),
+  canvasToBlob: jest.fn(() => mockCanvasToBlob()),
+}));
+
+const mockCanvasToBlob = () => of({ blob: true });
+
+/** @type {any} */
+const sampleSpec = {
+  layers: [],
+  dpi: 127,
+  scale: 10000,
+  projection: 'EPSG:3857',
+  center: [4, 40],
+  size: [100, 200],
+};
+
+const randomSpec = () => ({
+  ...sampleSpec,
+  scale: Math.ceil(Math.random() * 100000),
+});
+
+describe('jobs monitoring and creation', () => {
+  beforeEach(() => {});
+  describe('createNewJob', () => {
+    describe('when starting several jobs at the same time', () => {
+      let jobIds, specs;
+      beforeEach(async () => {
+        jobIds = [];
+        specs = [randomSpec(), randomSpec(), randomSpec()];
+        jobIds = await combineLatest(specs.map(createNewJob)).toPromise();
+      });
+      it('returns a different id for each job', () => {
+        expect(jobIds).toEqual([0, 1, 2]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #56

This simply checks that the job that we receive from the printer and that we consider "our" new job has a spec that matches the one we requested.

Also contains a bit of refactoring to allow testing this part of the logic.