### PR TITLE
Remove duplicated attributions inside computeAttributionsText function

### DIFF
--- a/src/shared/widgets/attributions.js
+++ b/src/shared/widgets/attributions.js
@@ -42,7 +42,9 @@ export function printAttributions(ctx, spec) {
 }
 
 /**
- * Returns the full attributions text of a spec
+ * Returns the attributions text of a spec.
+ * It concatenates all unique attributions from the layers.
+ * If no attributions are found, it returns 'Unknown source'.
  * @param {import('../../main/index.js').PrintSpec} spec
  * @return {string}
  */
@@ -51,6 +53,12 @@ export function computeAttributionsText(spec) {
     spec.layers
       .filter((layer) => !!layer.attribution)
       .map((layer) => layer.attribution)
+      .reduce((acc, attribution) => {
+        if (acc.indexOf(attribution) === -1) {
+          acc.push(attribution);
+        }
+        return acc;
+      }, [])
       .join(', ') || 'Unknown source'
   );
 }

--- a/test/unit/attributions.test.js
+++ b/test/unit/attributions.test.js
@@ -20,6 +20,18 @@ describe('attributions', () => {
         ).toBe('Text abcd, Ef Ghi');
       });
     });
+    describe('several layers with same attribution', () => {
+      it('computes the correct attributions', () => {
+        expect(
+          computeAttributionsText({
+            layers: [
+              { attribution: 'Text abcd' },
+              { attribution: 'Text abcd' },
+            ],
+          })
+        ).toBe('Text abcd');
+      });
+    });
     describe('no layer with attribution', () => {
       it('computes the correct attributions', () => {
         expect(


### PR DESCRIPTION
The Attribution control from openlayers remove duplicated attributions and I wanted to implement the same behavior within Inkmap.